### PR TITLE
Improved result print message by specifying unit

### DIFF
--- a/cmd/bulk_load_opentsdb/main.go
+++ b/cmd/bulk_load_opentsdb/main.go
@@ -147,7 +147,7 @@ func main() {
 	took := end.Sub(start)
 	rate := float64(itemsRead) / float64(took.Seconds())
 
-	fmt.Printf("loaded %d items in %fsec with %d workers (mean rate %f/sec)\n", itemsRead, took.Seconds(), workers, rate)
+	fmt.Printf("loaded %d items in %fsec with %d workers (mean values rate %f/sec)\n", itemsRead, took.Seconds(), workers, rate)
 
 	if reportHost != "" {
 		reportParams := &report.LoadReportParams{


### PR DESCRIPTION
Added 'values' word to specify that result actually means values rate