### PR TITLE
fixed default http client configuration

### DIFF
--- a/cmd/query_benchmarker_influxdb/fasthttp_client.go
+++ b/cmd/query_benchmarker_influxdb/fasthttp_client.go
@@ -28,9 +28,9 @@ func NewFastHTTPClient(host string, debug int, dialTimeout time.Duration, readTi
 			Dial: func(addr string) (net.Conn, error) {
 				return fasthttp.DialTimeout(addr, dialTimeout)
 			},
-			MaxIdleConnDuration: 1 * time.Hour,
-			ReadTimeout:         readTimeout,
-			WriteTimeout:        writeTimeout,
+			MaxIdleConnDuration: idleConnectionTimeout,
+			ReadTimeout: readTimeout,
+			WriteTimeout: writeTimeout,
 		},
 		HTTPClientCommon: HTTPClientCommon{
 			Host:       []byte(host),

--- a/cmd/query_benchmarker_influxdb/http_client.go
+++ b/cmd/query_benchmarker_influxdb/http_client.go
@@ -130,7 +130,7 @@ func (w *DefaultHTTPClient) HostString() string {
 }
 
 func (w *DefaultHTTPClient) Ping() {
-	req, _ := http.NewRequest("GET", w.HTTPClientCommon.HostString+"/ping", nil)
+	req, _ := http.NewRequest("GET", w.HTTPClientCommon.HostString + "/ping", nil)
 	resp, _ := w.client.Do(req)
 	defer resp.Body.Close()
 }

--- a/cmd/query_benchmarker_influxdb/http_client.go
+++ b/cmd/query_benchmarker_influxdb/http_client.go
@@ -27,9 +27,10 @@ func NewDefaultHTTPClient(host string, debug int, dialTimeout time.Duration, rea
 				Dial: (&net.Dialer{
 					Timeout: dialTimeout,
 				}).Dial,
-				MaxIdleConns:    1,
-				MaxConnsPerHost: 1,
-				IdleConnTimeout: 1 * time.Hour,
+				MaxIdleConns: 0, // unlimited
+				MaxIdleConnsPerHost: 100, // 0 would fallback to DefaultMaxIdleConnsPerHost ie. 2
+				MaxConnsPerHost: 0, // unlimited
+				IdleConnTimeout: idleConnectionTimeout,
 			},
 		},
 		HTTPClientCommon: HTTPClientCommon{
@@ -55,8 +56,14 @@ func (w *DefaultHTTPClient) Do(q *Query, opts *HTTPClientDoOptions) (lag float64
 	resp, err := w.client.Do(req)
 	lag = float64(time.Since(start).Nanoseconds()) / 1e6 // milliseconds
 
-	respBody, err := ioutil.ReadAll(resp.Body)
-	resp.Body.Close()
+	var respBody []byte
+	if err == nil {
+		respBody, err = ioutil.ReadAll(resp.Body)
+		resp.Body.Close()
+		if err != nil {
+			return
+		}
+	}
 
 	if (err != nil || resp.StatusCode != http.StatusOK) && opts.Debug == 5 {
 		values, _ := url.ParseQuery(string(uri))

--- a/cmd/query_benchmarker_influxdb/http_client_common.go
+++ b/cmd/query_benchmarker_influxdb/http_client_common.go
@@ -2,7 +2,10 @@ package main
 
 import "time"
 
-var UseFastHttp = true
+const DefaultIdleConnectionTimeout = 90 * time.Second
+
+var useFastHttp = true
+var idleConnectionTimeout = DefaultIdleConnectionTimeout
 
 // HTTPClient is a reusable HTTP Client.
 type HTTPClientCommon struct {
@@ -25,7 +28,7 @@ type HTTPClient interface {
 }
 
 func NewHTTPClient(host string, debug int, dialTimeout time.Duration, readTimeout time.Duration, writeTimeout time.Duration) HTTPClient {
-	if UseFastHttp {
+	if useFastHttp {
 		return NewFastHTTPClient(host, debug, dialTimeout, readTimeout, writeTimeout)
 	} else {
 		return NewDefaultHTTPClient(host, debug, dialTimeout, readTimeout, writeTimeout)

--- a/cmd/query_benchmarker_influxdb/http_client_pool.go
+++ b/cmd/query_benchmarker_influxdb/http_client_pool.go
@@ -40,6 +40,7 @@ func InitPools(clientsPerHost int, urls []string, debug int, dialTimeout time.Du
 	if clientsPerHost <= 0 {
 		return
 	}
+	idleConnectionTimeout = 1 * time.Hour
 	clientsPools = make(map[string]*HTTPClientPool)
 	for i := 0; i < len(urls); i++ {
 		fmt.Printf("Creating HTTP client pool for %v ", urls[i])
@@ -61,4 +62,5 @@ func InitPools(clientsPerHost int, urls []string, debug int, dialTimeout time.Du
 		fmt.Printf("\n")
 		clientsPools[hp.Host] = &hp
 	}
+	idleConnectionTimeout = DefaultIdleConnectionTimeout
 }

--- a/cmd/query_benchmarker_influxdb/main.go
+++ b/cmd/query_benchmarker_influxdb/main.go
@@ -701,7 +701,7 @@ func fprintStats(w io.Writer, statGroups statsMap) {
 		for len(paddedKey) < maxKeyLength {
 			paddedKey += " "
 		}
-		_, err := fmt.Fprintf(w, "%s : min: %8.2fms (%7.2f/sec), mean: %8.2fms (%7.2f/sec), moving mean: %8.2fms, moving mean trend: %8.2fms + %3.3f * x, moving median: %8.2fms, max: %7.2fms (%6.2f/sec), count: %8d, sum: %5.1fsec \n", paddedKey, v.Min, minRate, v.Mean, meanRate, movingAverageStat.Avg(), movingAverageStat.trendAvg.intercept, movingAverageStat.trendAvg.slope, movingAverageStat.Median(), v.Max, maxRate, v.Count, v.Sum/1e3)
+		_, err := fmt.Fprintf(w, "%s : min: %8.2fms (%7.2f/sec), mean: %8.2fms (%7.2f/sec), moving mean: %8.2fms, moving median: %8.2fms, max: %7.2fms (%6.2f/sec), count: %8d, sum: %5.1fsec \n", paddedKey, v.Min, minRate, v.Mean, meanRate, movingAverageStat.Avg(), movingAverageStat.Median(), v.Max, maxRate, v.Count, v.Sum/1e3)
 		if err != nil {
 			log.Fatal(err)
 		}

--- a/cmd/query_benchmarker_influxdb/main.go
+++ b/cmd/query_benchmarker_influxdb/main.go
@@ -199,7 +199,7 @@ func init() {
 
 	if httpClientType == "fast" || httpClientType == "default" {
 		fmt.Printf("Using HTTP client: %v\n", httpClientType)
-		UseFastHttp = httpClientType == "fast"
+		useFastHttp = httpClientType == "fast"
 	} else {
 		log.Fatalf("Unsupported HTPP client type: %v", httpClientType)
 	}

--- a/cmd/query_benchmarker_influxdb/main.go
+++ b/cmd/query_benchmarker_influxdb/main.go
@@ -275,7 +275,7 @@ func main() {
 	for i := 0; i < workers; i++ {
 		daemonUrl := daemonUrls[i%len(daemonUrls)]
 		workersGroup.Add(1)
-		w := CachedOrNewHTTPClient(daemonUrl, debug, dialTimeout, readTimeout, writeTimeout)
+		w := NewHTTPClient(daemonUrl, debug, dialTimeout, readTimeout, writeTimeout)
 		go processQueries(w, telemetryChanPoints, fmt.Sprintf("%d", i))
 	}
 	fmt.Printf("Started querying with %d workers\n", workers)
@@ -324,7 +324,7 @@ loop:
 					//fmt.Printf("Adding worker %d\n", workers)
 					daemonUrl := daemonUrls[workers%len(daemonUrls)]
 					workersGroup.Add(1)
-					w := CachedOrNewHTTPClient(daemonUrl, debug, dialTimeout, readTimeout, writeTimeout)
+					w := NewHTTPClient(daemonUrl, debug, dialTimeout, readTimeout, writeTimeout)
 					go processQueries(w, telemetryChanPoints, fmt.Sprintf("%d", workers))
 					workers++
 				}


### PR DESCRIPTION
- fixed default http client for multiple use
- setting idle connection timeout to reasonable value
- avoid using precreated http clients in query_benchmark_influxdb tool because it is useless and not properly done (will deprecate it in some future commit)