### PR TITLE
Elastic Search fixes for 6.4.3, influx bulk load improvement

### DIFF
--- a/cmd/bulk_load_es/main.go
+++ b/cmd/bulk_load_es/main.go
@@ -246,7 +246,7 @@ func main() {
 		}
 
 		if len(existingIndexTemplates) > 0 {
-			log.Fatal("There are index templates already in the data store. If you know what you are doing, clear them first with a command like:\ncurl -XDELETE 'http://localhost:9200/_template/*'")
+			log.Println("There are index templates already in the data store. If you know what you are doing, clear them first with a command like:\ncurl -XDELETE 'http://localhost:9200/_template/*'")
 		}
 
 		// check that there are no pre-existing indices:
@@ -256,7 +256,7 @@ func main() {
 		}
 
 		if len(existingIndices) > 0 {
-			log.Fatal("There are indices already in the data store. If you know what you are doing, clear them first with a command like:\ncurl -XDELETE 'http://localhost:9200/_all'")
+			log.Println("There are indices already in the data store. If you know what you are doing, clear them first with a command like:\ncurl -XDELETE 'http://localhost:9200/_all'")
 		}
 
 		// create the index template:
@@ -478,6 +478,7 @@ func createESTemplate(daemonUrl, indexTemplateName string, indexTemplateBodyTemp
 	if err != nil {
 		return err
 	}
+	req.Header.Add("Content-Type", "application/json")
 
 	client := &http.Client{}
 	resp, err := client.Do(req)
@@ -488,7 +489,8 @@ func createESTemplate(daemonUrl, indexTemplateName string, indexTemplateBodyTemp
 	// does the body need to be read into the void?
 
 	if resp.StatusCode != 200 {
-		return fmt.Errorf("bad mapping create")
+		body, _ := ioutil.ReadAll(resp.Body)
+		return fmt.Errorf("bad mapping create: %s", body)
 	}
 	return nil
 }

--- a/cmd/bulk_load_influx/http_writer.go
+++ b/cmd/bulk_load_influx/http_writer.go
@@ -11,6 +11,8 @@ import (
 	"github.com/valyala/fasthttp"
 )
 
+const DefaultIdleConnectionTimeout = 90 * time.Second
+
 var (
 	BackoffError        error  = fmt.Errorf("backpressure is needed")
 	backoffMagicWords0  []byte = []byte("engine: cache maximum memory size exceeded")
@@ -50,6 +52,7 @@ func NewHTTPWriter(c HTTPWriterConfig, consistency string) *HTTPWriter {
 	return &HTTPWriter{
 		client: fasthttp.Client{
 			Name: "bulk_load_influx",
+			MaxIdleConnDuration: DefaultIdleConnectionTimeout,
 		},
 
 		c:   c,

--- a/cmd/bulk_load_influx/main.go
+++ b/cmd/bulk_load_influx/main.go
@@ -565,6 +565,7 @@ func processBatches(w *HTTPWriter, backoffSrc chan bool, backoffDst chan struct{
 		// Write the batch: try until backoff is not needed.
 		if doLoad {
 			var err error
+			var extraSleep time.Duration = 0
 			for {
 				if useGzip {
 					compressedBatch := bufPool.Get().(*bytes.Buffer)
@@ -594,7 +595,8 @@ func processBatches(w *HTTPWriter, backoffSrc chan bool, backoffDst chan struct{
 						p.AddBoolField("backoff", true)
 						telemetrySink <- p
 					}
-					time.Sleep(backoff)
+					time.Sleep(backoff + extraSleep)
+					extraSleep += backoff
 				} else {
 					backoffSrc <- false
 					break

--- a/cmd/bulk_load_influx/main.go
+++ b/cmd/bulk_load_influx/main.go
@@ -565,7 +565,6 @@ func processBatches(w *HTTPWriter, backoffSrc chan bool, backoffDst chan struct{
 		// Write the batch: try until backoff is not needed.
 		if doLoad {
 			var err error
-			var extraSleep time.Duration = 0
 			for {
 				if useGzip {
 					compressedBatch := bufPool.Get().(*bytes.Buffer)
@@ -595,8 +594,7 @@ func processBatches(w *HTTPWriter, backoffSrc chan bool, backoffDst chan struct{
 						p.AddBoolField("backoff", true)
 						telemetrySink <- p
 					}
-					time.Sleep(backoff + extraSleep)
-					extraSleep += backoff
+					time.Sleep(backoff)
 				} else {
 					backoffSrc <- false
 					break

--- a/cmd/bulk_load_influx/main.go
+++ b/cmd/bulk_load_influx/main.go
@@ -646,10 +646,10 @@ func processBatches(w *HTTPWriter, backoffSrc chan bool, backoffDst chan struct{
 					lagMillis += float64(realDelay)
 				} else {
 					gvStart = now
-/*					if !wasBackOff {
+					//if !wasBackOff {
 						atomic.AddInt32(&speedUpRequest, 1)
-					}
-*/				}
+					//}
+				}
 				gvCount = 0
 			} else {
 				reportStat = false

--- a/cmd/bulk_load_influx/main.go
+++ b/cmd/bulk_load_influx/main.go
@@ -598,7 +598,7 @@ func processBatches(w *HTTPWriter, backoffSrc chan bool, backoffDst chan struct{
 					time.Sleep(sleepTime)
 					sleepTime += backoff // sleep longer if backpressure comes again
 					if sleepTime > 10 * backoff { // but not longer than 10x default backoff time
-						log.Printf("Sleeping on backoff response way too long (10 x %v)", backoff)
+						log.Printf("[worker %s] sleeping on backoff response way too long (10x %v)", telemetryWorkerLabel ,backoff)
 						sleepTime = 10 * backoff
 					}
 				} else {


### PR DESCRIPTION
- ES 6.4. contains preconfigured templates, so no failing in case of finding existing templates
- ES 6.4. requires valid Content-Type header when creating template
- ES:  Printing also response body in case of error
-influx: Failing gracefully, with final finish message