### PR TITLE
devlops_net mistakenly used devlops_redis's RedisFields

### DIFF
--- a/bulk_data_gen/devops/devops_net.go
+++ b/bulk_data_gen/devops/devops_net.go
@@ -63,7 +63,7 @@ func (m *NetMeasurement) ToPoint(p *Point) bool {
 	p.AppendTag(NetTags[0], m.interfaceName)
 
 	for i := range m.distributions {
-		p.AppendField(RedisFields[i].Label, int64(m.distributions[i].Get()))
+		p.AppendField(NetFields[i].Label, int64(m.distributions[i].Get()))
 	}
 	return true
 }


### PR DESCRIPTION
Is this a clerical error?
devlops_net mistakenly used devlops_redis's RedisFields