### PR TITLE
feature: add InfluxDB 2.x support

### DIFF
--- a/bulk_query/http/common.go
+++ b/bulk_query/http/common.go
@@ -22,6 +22,7 @@ type HTTPClientDoOptions struct {
 	PrettyPrintResponses bool
 	Path                 []byte
 	AuthToken            string
+	Accept               string
 }
 
 // HTTPClient interface.

--- a/bulk_query/http/common.go
+++ b/bulk_query/http/common.go
@@ -20,6 +20,8 @@ type HTTPClientDoOptions struct {
 	Authorization        string
 	Debug                int
 	PrettyPrintResponses bool
+	Path                 []byte
+	AuthToken            string
 }
 
 // HTTPClient interface.

--- a/bulk_query/http/fasthttp_client.go
+++ b/bulk_query/http/fasthttp_client.go
@@ -61,6 +61,10 @@ func (w *FastHTTPClient) Do(q *Query, opts *HTTPClientDoOptions) (lag float64, e
 	if opts.Authorization != "" {
 		req.Header.Add("Authorization", opts.Authorization)
 	}
+	if opts.AuthToken != "" {
+		req.Header.Add("Authorization", fmt.Sprintf("Token %s", opts.AuthToken))
+	}
+
 	req.SetBody(q.Body)
 	// Perform the request while tracking latency:
 	resp := fasthttp.AcquireResponse()

--- a/bulk_query/http/fasthttp_client.go
+++ b/bulk_query/http/fasthttp_client.go
@@ -58,6 +58,9 @@ func (w *FastHTTPClient) Do(q *Query, opts *HTTPClientDoOptions) (lag float64, e
 	if opts.ContentType != "" {
 		req.Header.SetContentType(opts.ContentType)
 	}
+	if opts.Accept != "" {
+		req.Header.Set("Accept", opts.Accept)
+	}
 	if opts.Authorization != "" {
 		req.Header.Add("Authorization", opts.Authorization)
 	}

--- a/bulk_query/http/http_client.go
+++ b/bulk_query/http/http_client.go
@@ -54,6 +54,9 @@ func (w *DefaultHTTPClient) Do(q *Query, opts *HTTPClientDoOptions) (lag float64
 	if opts.ContentType != "" {
 		req.Header.Add("Content-Type", opts.ContentType)
 	}
+	if opts.Accept != "" {
+		req.Header.Add("Accept", opts.Accept)
+	}
 	if opts.Authorization != "" {
 		req.Header.Add("Authorization", opts.Authorization)
 	}

--- a/bulk_query/http/http_client.go
+++ b/bulk_query/http/http_client.go
@@ -54,6 +54,9 @@ func (w *DefaultHTTPClient) Do(q *Query, opts *HTTPClientDoOptions) (lag float64
 	if opts.Authorization != "" {
 		req.Header.Add("Authorization", opts.Authorization)
 	}
+	if opts.AuthToken != "" {
+		req.Header.Add("Authorization", fmt.Sprintf("Token %s", opts.AuthToken))
+	}
 
 	start := time.Now()
 	resp, err := w.client.Do(req)

--- a/bulk_query/http/http_client.go
+++ b/bulk_query/http/http_client.go
@@ -51,6 +51,9 @@ func (w *DefaultHTTPClient) Do(q *Query, opts *HTTPClientDoOptions) (lag float64
 
 	// populate a request with data from the Query:
 	req, err := http.NewRequest(string(q.Method), string(uri), bytes.NewBuffer(q.Body)) // TODO performance
+	if opts.ContentType != "" {
+		req.Header.Add("Content-Type", opts.ContentType)
+	}
 	if opts.Authorization != "" {
 		req.Header.Add("Authorization", opts.Authorization)
 	}

--- a/bulk_query_gen/influxdb/influx_common.go
+++ b/bulk_query_gen/influxdb/influx_common.go
@@ -48,8 +48,11 @@ func (d *InfluxCommon) getHttpQuery(humanLabel, intervalStart, query string, q *
 		q.Path = []byte(fmt.Sprintf("/query?%s", getValues.Encode()))
 		q.Body = nil
 	} else {
+		getValues := url.Values{}
+		getValues.Set("org", "my-org")
 		q.Method = []byte("POST")
-		q.Path = []byte("/api/v2/query")
+		//q.Path = []byte("/api/v2/query")
+		q.Path = []byte(fmt.Sprintf("/api/v2/query?%s", getValues.Encode()))
 		q.Body = []byte(query)
 	}
 }

--- a/bulk_query_gen/influxdb/influx_common.go
+++ b/bulk_query_gen/influxdb/influx_common.go
@@ -48,11 +48,8 @@ func (d *InfluxCommon) getHttpQuery(humanLabel, intervalStart, query string, q *
 		q.Path = []byte(fmt.Sprintf("/query?%s", getValues.Encode()))
 		q.Body = nil
 	} else {
-		getValues := url.Values{}
-		getValues.Set("org", "my-org")
 		q.Method = []byte("POST")
-		//q.Path = []byte("/api/v2/query")
-		q.Path = []byte(fmt.Sprintf("/api/v2/query?%s", getValues.Encode()))
+		//q.Path will be set in query_benchmarker_influxdb
 		q.Body = []byte(query)
 	}
 }

--- a/bulk_query_gen/influxdb/influx_common.go
+++ b/bulk_query_gen/influxdb/influx_common.go
@@ -38,20 +38,18 @@ func newInfluxCommon(lang Language, dbName string, interval bulkQuerygen.TimeInt
 func (d *InfluxCommon) getHttpQuery(humanLabel, intervalStart, query string, q *bulkQuerygen.HTTPQuery) {
 	q.HumanLabel = []byte(humanLabel)
 	q.HumanDescription = []byte(fmt.Sprintf("%s: %s", humanLabel, intervalStart))
+	q.Language = d.language.String()
 
-	getValues := url.Values{}
 	if d.language == InfluxQL {
+		getValues := url.Values{}
 		getValues.Set("db", d.DatabaseName)
 		getValues.Set("q", query)
 		q.Method = []byte("GET")
 		q.Path = []byte(fmt.Sprintf("/query?%s", getValues.Encode()))
 		q.Body = nil
 	} else {
-		postValues := url.Values{}
-		postValues.Set("query", query)
-		getValues.Set("organization", "my-org")
 		q.Method = []byte("POST")
-		q.Path = []byte(fmt.Sprintf("/query?%s", getValues.Encode()))
-		q.Body = []byte(postValues.Encode())
+		q.Path = []byte("/api/v2/query")
+		q.Body = []byte(query)
 	}
 }

--- a/bulk_query_gen/influxdb/influx_dashboard_all.go
+++ b/bulk_query_gen/influxdb/influx_dashboard_all.go
@@ -42,6 +42,26 @@ func NewFluxDashboardAll(dbConfig bulkQuerygen.DatabaseConfig, interval bulkQuer
 	underlying := newInfluxDashboard(Flux, dbConfig, interval, duration, scaleVar).(*InfluxDashboard)
 	return &InfluxDashboardAll{
 		InfluxDashboard: *underlying,
+		Gens: []bulkQuerygen.QueryGenerator{
+			NewFluxDashboardAvailability(dbConfig, interval, duration, scaleVar),
+			NewFluxDashboardCpuNum(dbConfig, interval, duration, scaleVar),
+			NewFluxDashboardCpuUtilization(dbConfig, interval, duration, scaleVar),
+			NewFluxDashboardDiskAllocated(dbConfig, interval, duration, scaleVar),
+			NewFluxDashboardDiskUsage(dbConfig, interval, duration, scaleVar),
+			NewFluxDashboardDiskUtilization(dbConfig, interval, duration, scaleVar),
+			NewFluxDashboardHttpRequestDuration(dbConfig, interval, duration, scaleVar),
+			NewFluxDashboardHttpRequests(dbConfig, interval, duration, scaleVar),
+			NewFluxDashboardKapaCpu(dbConfig, interval, duration, scaleVar),
+			NewFluxDashboardKapaLoad(dbConfig, interval, duration, scaleVar),
+			NewFluxDashboardKapaRam(dbConfig, interval, duration, scaleVar),
+			NewFluxDashboardMemoryTotal(dbConfig, interval, duration, scaleVar),
+			NewFluxDashboardMemoryUtilization(dbConfig, interval, duration, scaleVar),
+			NewFluxDashboardNginxRequests(dbConfig, interval, duration, scaleVar),
+			NewFluxDashboardQueueBytes(dbConfig, interval, duration, scaleVar),
+			NewFluxDashboardRedisMemoryUtilization(dbConfig, interval, duration, scaleVar),
+			NewFluxDashboardSystemLoad(dbConfig, interval, duration, scaleVar),
+			NewFluxDashboardThroughput(dbConfig, interval, duration, scaleVar),
+		},
 	}
 }
 

--- a/bulk_query_gen/influxdb/influx_dashboard_availability.go
+++ b/bulk_query_gen/influxdb/influx_dashboard_availability.go
@@ -36,17 +36,16 @@ func (d *InfluxDashboardAvailability) Dispatch(i int) bulkQuerygen.Query {
 		query = fmt.Sprintf(`data = from(bucket:"%s") `+
 			`|> range(start:%s, stop:%s) `+
 			`|> filter(fn:(r) => r._measurement == "status" and r._field == "service_up" and r._cluster_id == "%s") `+
-			`|> keep(columns:["_start", "_stop", "_time", "_value"])\n`+
-			`sum = data |> sum()\n`+
-			`count = data |> count()\n`+
+			`|> keep(columns:["_start", "_stop", "_time", "_value"])`+"\n"+
+			`sum = data |> sum()`+"\n"+
+			`count = data |> count()`+"\n"+
 			`join(tables:{sum:sum,count:count},on:["_time"]) `+
-			`|> map(fn: (r) => ({_time:%s,_value:(float(v:r._value_sum) / float(v:r._value_count) * 100.0))) `+
+			`|> map(fn: (r) => ({_time:r._start_sum,_value:(float(v:r._value_sum) / float(v:r._value_count) * 100.0))) `+
 			`|> keep(columns:["_time", "_value"]) `+
 			`|> yield()`,
 			d.DatabaseName,
 			interval.StartString(), interval.EndString(),
-			d.GetRandomClusterId(),
-			interval.StartString())
+			d.GetRandomClusterId())
 	}
 
 	humanLabel := fmt.Sprintf("InfluxDB (%s) Availability (Percent), rand cluster in %s", d.language.String(), interval.Duration())

--- a/bulk_query_gen/influxdb/influx_dashboard_availability.go
+++ b/bulk_query_gen/influxdb/influx_dashboard_availability.go
@@ -35,7 +35,7 @@ func (d *InfluxDashboardAvailability) Dispatch(i int) bulkQuerygen.Query {
 	} else { // TODO fill(linear) how??
 		query = fmt.Sprintf(`data = from(bucket:"%s") `+
 			`|> range(start:%s, stop:%s) `+
-			`|> filter(fn:(r) => r._measurement == "status" and r._field == "service_up" and r_cluster_id == "%s") `+
+			`|> filter(fn:(r) => r._measurement == "status" and r._field == "service_up" and r._cluster_id == "%s") `+
 			`|> keep(columns:["_start", "_stop", "_time", "_value"])\n`+
 			`sum = data |> sum()\n`+
 			`count = data |> count()\n`+

--- a/bulk_query_gen/influxdb/influx_dashboard_availability.go
+++ b/bulk_query_gen/influxdb/influx_dashboard_availability.go
@@ -30,7 +30,24 @@ func (d *InfluxDashboardAvailability) Dispatch(i int) bulkQuerygen.Query {
 
 	var query string
 	//SELECT (sum("service_up") / count("service_up"))*100 AS "up_time" FROM "watcher"."autogen"."ping" WHERE cluster_id = :Cluster_Id: and time > :dashboardTime: FILL(linear)
-	query = fmt.Sprintf("SELECT (sum(\"service_up\") / count(\"service_up\"))*100 AS \"up_time\" FROM status WHERE cluster_id = '%s' and %s FILL(linear)", d.GetRandomClusterId(), d.GetTimeConstraint(interval))
+	if d.language == InfluxQL {
+		query = fmt.Sprintf("SELECT (sum(\"service_up\") / count(\"service_up\"))*100 AS \"up_time\" FROM status WHERE cluster_id = '%s' and %s FILL(linear)", d.GetRandomClusterId(), d.GetTimeConstraint(interval))
+	} else { // TODO fill(linear) how??
+		query = fmt.Sprintf(`data = from(bucket:"%s") `+
+			`|> range(start:%s, stop:%s) `+
+			`|> filter(fn:(r) => r._measurement == "status" and r._field == "service_up" and r_cluster_id == "%s") `+
+			`|> keep(columns:["_start", "_stop", "_time", "_value"])\n`+
+			`sum = data |> sum()\n`+
+			`count = data |> count()\n`+
+			`join(tables:{sum:sum,count:count},on:["_time"]) `+
+			`|> map(fn: (r) => ({_time:%s,_value:(float(v:r._value_sum) / float(v:r._value_count) * 100.0))) `+
+			`|> keep(columns:["_time", "_value"]) `+
+			`|> yield()`,
+			d.DatabaseName,
+			interval.StartString(), interval.EndString(),
+			d.GetRandomClusterId(),
+			interval.StartString())
+	}
 
 	humanLabel := fmt.Sprintf("InfluxDB (%s) Availability (Percent), rand cluster in %s", d.language.String(), interval.Duration())
 

--- a/bulk_query_gen/influxdb/influx_dashboard_cpu_num.go
+++ b/bulk_query_gen/influxdb/influx_dashboard_cpu_num.go
@@ -35,7 +35,7 @@ func (d *InfluxDashboardCpuNum) Dispatch(i int) bulkQuerygen.Query {
 	} else {
 		query = fmt.Sprintf(`from(bucket:"%s") `+
 			`|> range(start:%s, stop:%s) `+
-			`|> filter(fn:(r) => r._measurement == "system" and r._field == "n_cpus" and r_cluster_id == "%s") `+
+			`|> filter(fn:(r) => r._measurement == "system" and r._field == "n_cpus" and r._cluster_id == "%s") `+
 			`|> keep(columns:["_start", "_stop", "_time", "_value"]) `+
 			`|> window(every:1m) `+ // TODO replace with aggregateWindow when it is fixed
 			`|> max() `+

--- a/bulk_query_gen/influxdb/influx_dashboard_cpu_num.go
+++ b/bulk_query_gen/influxdb/influx_dashboard_cpu_num.go
@@ -37,10 +37,7 @@ func (d *InfluxDashboardCpuNum) Dispatch(i int) bulkQuerygen.Query {
 			`|> range(start:%s, stop:%s) `+
 			`|> filter(fn:(r) => r._measurement == "system" and r._field == "n_cpus" and r._cluster_id == "%s") `+
 			`|> keep(columns:["_start", "_stop", "_time", "_value"]) `+
-			`|> window(every:1m) `+ // TODO replace with aggregateWindow when it is fixed
-			`|> max() `+
-			`|> duplicate(column: "_stop", as: "_time") `+
-			`|> window(every: inf) `+ //
+			`|> aggregateWindow(every: 1m, fn: max, createEmpty: false) `+
 			`|> last() `+
 			`|> keep(columns:["_time", "_value"]) `+
 			`|> yield()`,

--- a/bulk_query_gen/influxdb/influx_dashboard_cpu_utilization.go
+++ b/bulk_query_gen/influxdb/influx_dashboard_cpu_utilization.go
@@ -35,7 +35,7 @@ func (d *InfluxDashboardCpuUtilization) Dispatch(i int) bulkQuerygen.Query {
 	} else {
 		query = fmt.Sprintf(`from(bucket:"%s") `+
 			`|> range(start:%s, stop:%s) `+
-			`|> filter(fn:(r) => r._measurement == "cpu" and r._field == "usage_user" and r_cluster_id == "%s") `+
+			`|> filter(fn:(r) => r._measurement == "cpu" and r._field == "usage_user" and r._cluster_id == "%s") `+
 			`|> keep(columns:["_start", "_stop", "_time", "_value", "hostname"]) `+
 			`|> group(columns:["hostname"]) `+
 			`|> aggregateWindow(every: 1m, fn: mean, createEmpty: false) `+

--- a/bulk_query_gen/influxdb/influx_dashboard_cpu_utilization.go
+++ b/bulk_query_gen/influxdb/influx_dashboard_cpu_utilization.go
@@ -29,8 +29,22 @@ func (d *InfluxDashboardCpuUtilization) Dispatch(i int) bulkQuerygen.Query {
 	q, interval := d.InfluxDashboard.DispatchCommon(i)
 
 	var query string
-	//c "telegraf"."default"."cpu" WHERE time > :dashboardTime: and cluster_id = :Cluster_Id: GROUP BY host, time(1m)
-	query = fmt.Sprintf("SELECT mean(\"usage_user\") FROM cpu WHERE cluster_id = '%s' and %s group by hostname,time(1m)", d.GetRandomClusterId(), d.GetTimeConstraint(interval))
+	//SELECT mean("usage_user") FROM "telegraf"."default"."cpu" WHERE time > :dashboardTime: and cluster_id = :Cluster_Id: GROUP BY host, time(1m)
+	if d.language == InfluxQL {
+		query = fmt.Sprintf("SELECT mean(\"usage_user\") FROM cpu WHERE cluster_id = '%s' and %s group by hostname,time(1m)", d.GetRandomClusterId(), d.GetTimeConstraint(interval))
+	} else {
+		query = fmt.Sprintf(`from(bucket:"%s") `+
+			`|> range(start:%s, stop:%s) `+
+			`|> filter(fn:(r) => r._measurement == "cpu" and r._field == "usage_user" and r_cluster_id == "%s") `+
+			`|> keep(columns:["_start", "_stop", "_time", "_value", "hostname"]) `+
+			`|> group(columns:["hostname"]) `+
+			`|> aggregateWindow(every: 1m, fn: mean, createEmpty: false) `+
+			`|> keep(columns: ["_time", "_value", "hostname"]) `+
+			`|> yield()`,
+			d.DatabaseName,
+			interval.StartString(), interval.EndString(),
+			d.GetRandomClusterId())
+	}
 
 	humanLabel := fmt.Sprintf("InfluxDB (%s) CPU Utilization (Percent), rand cluster, %s by host, 1m", d.language.String(), interval.Duration())
 

--- a/bulk_query_gen/influxdb/influx_dashboard_disk_allocated.go
+++ b/bulk_query_gen/influxdb/influx_dashboard_disk_allocated.go
@@ -37,9 +37,7 @@ func (d *InfluxDashboardDiskAllocated) Dispatch(i int) bulkQuerygen.Query {
 			`|> range(start:%s, stop:%s) `+
 			`|> filter(fn:(r) => r._measurement == "disk" and r._field == "total" and r._cluster_id == "%s" and r.hostname =~ /data/) `+
 			`|> keep(columns:["_start", "_stop", "_time", "_value"]) `+
-			`|> window(every: 120s) `+ // TODO replace with aggregateWindow when it is fixed
-			`|> max() `+
-			`|> window(every: inf) `+
+			`|> aggregateWindow(every: 120s, fn: max, createEmpty: false) `+
 			`|> map(fn: (r) => ({_time:r._time, _value:r._value / 1073741824})) `+
 			`|> last() `+
 			`|> keep(columns:["_time", "_value"]) `+

--- a/bulk_query_gen/influxdb/influx_dashboard_disk_allocated.go
+++ b/bulk_query_gen/influxdb/influx_dashboard_disk_allocated.go
@@ -35,7 +35,7 @@ func (d *InfluxDashboardDiskAllocated) Dispatch(i int) bulkQuerygen.Query {
 	} else {
 		query = fmt.Sprintf(`from(bucket:"%s") `+
 			`|> range(start:%s, stop:%s) `+
-			`|> filter(fn:(r) => r._measurement == "disk" and r._field == "total" and r_cluster_id == "%s" and hostname =~ /data/) `+
+			`|> filter(fn:(r) => r._measurement == "disk" and r._field == "total" and r._cluster_id == "%s" and hostname =~ /data/) `+
 			`|> keep(columns:["_start", "_stop", "_time", "_value"]) `+
 			`|> window(every: 120s) `+ // TODO replace with aggregateWindow when it is fixed
 			`|> max() `+

--- a/bulk_query_gen/influxdb/influx_dashboard_disk_allocated.go
+++ b/bulk_query_gen/influxdb/influx_dashboard_disk_allocated.go
@@ -30,7 +30,24 @@ func (d *InfluxDashboardDiskAllocated) Dispatch(i int) bulkQuerygen.Query {
 
 	var query string
 	//SELECT last("max") from (SELECT max("total")/1073741824 FROM "telegraf"."default"."disk" WHERE time > :dashboardTime: and cluster_id = :Cluster_Id: and host =~ /.data./ GROUP BY time(120s))
-	query = fmt.Sprintf("SELECT last(\"max\") from (SELECT max(\"total\")/1073741824 FROM disk WHERE cluster_id = '%s' and %s and hostname =~ /data/ group by time(120s))", d.GetRandomClusterId(), d.GetTimeConstraint(interval))
+	if d.language == InfluxQL {
+		query = fmt.Sprintf("SELECT last(\"max\") from (SELECT max(\"total\")/1073741824 FROM disk WHERE cluster_id = '%s' and %s and hostname =~ /data/ group by time(120s))", d.GetRandomClusterId(), d.GetTimeConstraint(interval))
+	} else {
+		query = fmt.Sprintf(`from(bucket:"%s") `+
+			`|> range(start:%s, stop:%s) `+
+			`|> filter(fn:(r) => r._measurement == "disk" and r._field == "total" and r_cluster_id == "%s" and hostname =~ /data/) `+
+			`|> keep(columns:["_start", "_stop", "_time", "_value"]) `+
+			`|> window(every: 120s) `+ // TODO replace with aggregateWindow when it is fixed
+			`|> max() `+
+			`|> window(every: inf) `+
+			`|> map(fn: (r) => ({_time:r._time, _value:r._value / 1073741824})) `+
+			`|> last() `+
+			`|> keep(columns:["_time", "_value"]) `+
+			`|> yield()`,
+			d.DatabaseName,
+			interval.StartString(), interval.EndString(),
+			d.GetRandomClusterId())
+	}
 
 	humanLabel := fmt.Sprintf("InfluxDB (%s) Disk Allocated (GB), rand cluster, %s by 120s", d.language.String(), interval.Duration())
 

--- a/bulk_query_gen/influxdb/influx_dashboard_disk_allocated.go
+++ b/bulk_query_gen/influxdb/influx_dashboard_disk_allocated.go
@@ -35,7 +35,7 @@ func (d *InfluxDashboardDiskAllocated) Dispatch(i int) bulkQuerygen.Query {
 	} else {
 		query = fmt.Sprintf(`from(bucket:"%s") `+
 			`|> range(start:%s, stop:%s) `+
-			`|> filter(fn:(r) => r._measurement == "disk" and r._field == "total" and r._cluster_id == "%s" and hostname =~ /data/) `+
+			`|> filter(fn:(r) => r._measurement == "disk" and r._field == "total" and r._cluster_id == "%s" and r.hostname =~ /data/) `+
 			`|> keep(columns:["_start", "_stop", "_time", "_value"]) `+
 			`|> window(every: 120s) `+ // TODO replace with aggregateWindow when it is fixed
 			`|> max() `+

--- a/bulk_query_gen/influxdb/influx_dashboard_disk_usage.go
+++ b/bulk_query_gen/influxdb/influx_dashboard_disk_usage.go
@@ -35,7 +35,7 @@ func (d *InfluxDashboardDiskUsage) Dispatch(i int) bulkQuerygen.Query {
 	} else {
 		query = fmt.Sprintf(`from(bucket:"%s") `+
 			`|> range(start:%s, stop:%s) `+
-			`|> filter(fn:(r) => r._measurement == "disk" and r._field == "used_percent" and r._cluster_id == "%s" and hostname =~ /data/) `+
+			`|> filter(fn:(r) => r._measurement == "disk" and r._field == "used_percent" and r._cluster_id == "%s" and r.hostname =~ /data/) `+
 			`|> keep(columns:["_start", "_stop", "_time", "_value"]) `+
 			`|> last() `+
 			`|> keep(columns:["_time", "_value"]) `+

--- a/bulk_query_gen/influxdb/influx_dashboard_disk_usage.go
+++ b/bulk_query_gen/influxdb/influx_dashboard_disk_usage.go
@@ -30,7 +30,20 @@ func (d *InfluxDashboardDiskUsage) Dispatch(i int) bulkQuerygen.Query {
 
 	var query string
 	//SELECT last("used_percent") AS "mean_used_percent" FROM "telegraf"."default"."disk" WHERE time > :dashboardTime: and cluster_id = :Cluster_Id: and host =~ /.data./
-	query = fmt.Sprintf("SELECT last(\"used_percent\") AS \"mean_used_percent\" FROM disk WHERE cluster_id = '%s' and %s and hostname =~ /data/", d.GetRandomClusterId(), d.GetTimeConstraint(interval))
+	if d.language == InfluxQL {
+		query = fmt.Sprintf("SELECT last(\"used_percent\") AS \"mean_used_percent\" FROM disk WHERE cluster_id = '%s' and %s and hostname =~ /data/", d.GetRandomClusterId(), d.GetTimeConstraint(interval))
+	} else {
+		query = fmt.Sprintf(`from(bucket:"%s") `+
+			`|> range(start:%s, stop:%s) `+
+			`|> filter(fn:(r) => r._measurement == "disk" and r._field == "used_percent" and r_cluster_id == "%s" and hostname =~ /data/) `+
+			`|> keep(columns:["_start", "_stop", "_time", "_value"]) `+
+			`|> last() `+
+			`|> keep(columns:["_time", "_value"]) `+
+			`|> yield()`,
+			d.DatabaseName,
+			interval.StartString(), interval.EndString(),
+			d.GetRandomClusterId())
+	}
 
 	humanLabel := fmt.Sprintf("InfluxDB (%s) Disk Usage (GB), rand cluster, %s", d.language.String(), interval.Duration())
 

--- a/bulk_query_gen/influxdb/influx_dashboard_disk_usage.go
+++ b/bulk_query_gen/influxdb/influx_dashboard_disk_usage.go
@@ -35,7 +35,7 @@ func (d *InfluxDashboardDiskUsage) Dispatch(i int) bulkQuerygen.Query {
 	} else {
 		query = fmt.Sprintf(`from(bucket:"%s") `+
 			`|> range(start:%s, stop:%s) `+
-			`|> filter(fn:(r) => r._measurement == "disk" and r._field == "used_percent" and r_cluster_id == "%s" and hostname =~ /data/) `+
+			`|> filter(fn:(r) => r._measurement == "disk" and r._field == "used_percent" and r._cluster_id == "%s" and hostname =~ /data/) `+
 			`|> keep(columns:["_start", "_stop", "_time", "_value"]) `+
 			`|> last() `+
 			`|> keep(columns:["_time", "_value"]) `+

--- a/bulk_query_gen/influxdb/influx_dashboard_disk_utilization.go
+++ b/bulk_query_gen/influxdb/influx_dashboard_disk_utilization.go
@@ -30,7 +30,23 @@ func (d *InfluxDashboardDiskUtilization) Dispatch(i int) bulkQuerygen.Query {
 
 	var query string
 	//SELECT max("used_percent") FROM "telegraf"."default"."disk" WHERE "cluster_id" = :Cluster_Id: AND "path" = '/influxdb/conf' AND time > :dashboardTime: AND host =~ /.data./ GROUP BY time(1m), "host"
-	query = fmt.Sprintf("SELECT max(\"used_percent\") FROM disk WHERE cluster_id = '%s' and \"path\" = '/dev/sda1' and %s AND hostname =~ /data/ group by time(1m), \"hostname\"", d.GetRandomClusterId(), d.GetTimeConstraint(interval))
+	if d.language == InfluxQL {
+		query = fmt.Sprintf("SELECT max(\"used_percent\") FROM disk WHERE cluster_id = '%s' and \"path\" = '/dev/sda1' and %s AND hostname =~ /data/ group by time(1m), \"hostname\"", d.GetRandomClusterId(), d.GetTimeConstraint(interval))
+	} else {
+		query = fmt.Sprintf(`from(bucket:"%s") `+
+			`|> range(start:%s, stop:%s) `+
+			`|> filter(fn:(r) => r._measurement == "disk" and r._field == "used_percent" and r_cluster_id == "%s" and r.path == "/dev/sda1" and hostname =~ /data/) `+
+			`|> keep(columns:["_start", "_stop", "_time", "_value", "hostname"]) `+
+			`|> group(columns: ["hostname"]) `+
+			`|> window(every: 1m) `+ // TODO replace window-max-window with aggregateWindow(every: 1m, fn: max) when it works
+			`|> max() `+
+			`|> window(every: inf) `+
+			`|> keep(columns: ["_time","_value"]) `+
+			`|> yield()`,
+			d.DatabaseName,
+			interval.StartString(), interval.EndString(),
+			d.GetRandomClusterId())
+	}
 
 	humanLabel := fmt.Sprintf("InfluxDB (%s) Disk Utilization (Percent), rand cluster, %s by 1m", d.language.String(), interval.Duration())
 

--- a/bulk_query_gen/influxdb/influx_dashboard_disk_utilization.go
+++ b/bulk_query_gen/influxdb/influx_dashboard_disk_utilization.go
@@ -35,13 +35,13 @@ func (d *InfluxDashboardDiskUtilization) Dispatch(i int) bulkQuerygen.Query {
 	} else {
 		query = fmt.Sprintf(`from(bucket:"%s") `+
 			`|> range(start:%s, stop:%s) `+
-			`|> filter(fn:(r) => r._measurement == "disk" and r._field == "used_percent" and r._cluster_id == "%s" and r.path == "/dev/sda1" and hostname =~ /data/) `+
+			`|> filter(fn:(r) => r._measurement == "disk" and r._field == "used_percent" and r._cluster_id == "%s" and r.path == "/dev/sda1" and r.hostname =~ /data/) `+
 			`|> keep(columns:["_start", "_stop", "_time", "_value", "hostname"]) `+
-			`|> group(columns: ["hostname"]) `+
 			`|> window(every: 1m) `+ // TODO replace window-max-window with aggregateWindow(every: 1m, fn: max) when it works
 			`|> max() `+
 			`|> window(every: inf) `+
-			`|> keep(columns: ["_time","_value"]) `+
+			`|> keep(columns: ["_time","_value", "hostname"]) `+
+			`|> group(columns: ["hostname"]) `+
 			`|> yield()`,
 			d.DatabaseName,
 			interval.StartString(), interval.EndString(),

--- a/bulk_query_gen/influxdb/influx_dashboard_disk_utilization.go
+++ b/bulk_query_gen/influxdb/influx_dashboard_disk_utilization.go
@@ -37,9 +37,7 @@ func (d *InfluxDashboardDiskUtilization) Dispatch(i int) bulkQuerygen.Query {
 			`|> range(start:%s, stop:%s) `+
 			`|> filter(fn:(r) => r._measurement == "disk" and r._field == "used_percent" and r._cluster_id == "%s" and r.path == "/dev/sda1" and r.hostname =~ /data/) `+
 			`|> keep(columns:["_start", "_stop", "_time", "_value", "hostname"]) `+
-			`|> window(every: 1m) `+ // TODO replace window-max-window with aggregateWindow(every: 1m, fn: max) when it works
-			`|> max() `+
-			`|> window(every: inf) `+
+			`|> aggregateWindow(every: 1m, fn: max, createEmpty: false) `+
 			`|> keep(columns: ["_time","_value", "hostname"]) `+
 			`|> group(columns: ["hostname"]) `+
 			`|> yield()`,

--- a/bulk_query_gen/influxdb/influx_dashboard_disk_utilization.go
+++ b/bulk_query_gen/influxdb/influx_dashboard_disk_utilization.go
@@ -35,7 +35,7 @@ func (d *InfluxDashboardDiskUtilization) Dispatch(i int) bulkQuerygen.Query {
 	} else {
 		query = fmt.Sprintf(`from(bucket:"%s") `+
 			`|> range(start:%s, stop:%s) `+
-			`|> filter(fn:(r) => r._measurement == "disk" and r._field == "used_percent" and r_cluster_id == "%s" and r.path == "/dev/sda1" and hostname =~ /data/) `+
+			`|> filter(fn:(r) => r._measurement == "disk" and r._field == "used_percent" and r._cluster_id == "%s" and r.path == "/dev/sda1" and hostname =~ /data/) `+
 			`|> keep(columns:["_start", "_stop", "_time", "_value", "hostname"]) `+
 			`|> group(columns: ["hostname"]) `+
 			`|> window(every: 1m) `+ // TODO replace window-max-window with aggregateWindow(every: 1m, fn: max) when it works

--- a/bulk_query_gen/influxdb/influx_dashboard_http_request_duration.go
+++ b/bulk_query_gen/influxdb/influx_dashboard_http_request_duration.go
@@ -45,8 +45,8 @@ func (d *InfluxDashboardHttpRequestDuration) Dispatch(i int) bulkQuerygen.Query 
 			`|> quantile(q: 0.99, method: "estimate_tdigest") `+
 			`|> duplicate(column: "_stop", as: "_time") `+
 			`|> window(every: inf) `+
-			`|> derivative(nonNegative: true)\n`+
-			`ndp_conn = from(bucket:"%s") `+
+			`|> derivative(nonNegative: true)`+"\n"+
+			`ndm_conn = from(bucket:"%s") `+
 			`|> range(start:%s, stop:%s) `+
 			`|> filter(fn:(r) => r._measurement == "redis" and r._field == "total_connections_received" and r._cluster_id == "%s") `+
 			`|> keep(columns:["_start", "_stop", "_time", "_value", "hostname"]) `+
@@ -57,7 +57,7 @@ func (d *InfluxDashboardHttpRequestDuration) Dispatch(i int) bulkQuerygen.Query 
 			`|> drop(columns: ["_time"]) `+
 			`|> duplicate(column: "_stop", as: "_time") `+
 			`|> window(every: inf) `+
-			`|> derivative(nonNegative: true)\n`+
+			`|> derivative(nonNegative: true)`+"\n"+
 			`join(tables:{ndp_uptime:ndp_uptime,ndm_conn:ndm_conn},on: ["_time","hostname"]) `+
 			`|> map(fn: (r) => ({_time:r._time,_value:(r._value_ndp_uptime / r._value_ndm_conn)})) `+
 			`|> keep(columns:["_time", "_value"]) `+

--- a/bulk_query_gen/influxdb/influx_dashboard_http_request_duration.go
+++ b/bulk_query_gen/influxdb/influx_dashboard_http_request_duration.go
@@ -37,7 +37,7 @@ func (d *InfluxDashboardHttpRequestDuration) Dispatch(i int) bulkQuerygen.Query 
 	} else {
 		query = fmt.Sprintf(`ndp_uptime = from(bucket:"%s") `+
 			`|> range(start:%s, stop:%s) `+
-			`|> filter(fn:(r) => r._measurement == "redis" and r._field == "uptime_in_seconds" and r_cluster_id == "%s") `+
+			`|> filter(fn:(r) => r._measurement == "redis" and r._field == "uptime_in_seconds" and r._cluster_id == "%s") `+
 			`|> keep(columns:["_start", "_stop", "_time", "_value", "hostname"]) `+
 			`|> map(fn: (r) => ({_time:r._time,_start:r._start,_stop:r._stop,_time:r._time,_value:float(v:r._value),hostname:r.hostname})) `+
 			`|> group(columns: ["hostname"]) `+
@@ -48,7 +48,7 @@ func (d *InfluxDashboardHttpRequestDuration) Dispatch(i int) bulkQuerygen.Query 
 			`|> derivative(nonNegative: true)\n`+
 			`ndp_uptime = from(bucket:"%s") `+
 			`|> range(start:%s, stop:%s) `+
-			`|> filter(fn:(r) => r._measurement == "redis" and r._field == "uptime_in_seconds" and r_cluster_id == "%s") `+
+			`|> filter(fn:(r) => r._measurement == "redis" and r._field == "uptime_in_seconds" and r._cluster_id == "%s") `+
 			`|> keep(columns:["_start", "_stop", "_time", "_value", "hostname"]) `+
 			`|> map(fn: (r) => ({_time:r._time,_start:r._start,_stop:r._stop,_time:r._time,_value:float(v:r._value),hostname:r.hostname})) `+
 			`|> group(columns: ["hostname"]) `+

--- a/bulk_query_gen/influxdb/influx_dashboard_http_request_duration.go
+++ b/bulk_query_gen/influxdb/influx_dashboard_http_request_duration.go
@@ -46,9 +46,9 @@ func (d *InfluxDashboardHttpRequestDuration) Dispatch(i int) bulkQuerygen.Query 
 			`|> duplicate(column: "_stop", as: "_time") `+
 			`|> window(every: inf) `+
 			`|> derivative(nonNegative: true)\n`+
-			`ndp_uptime = from(bucket:"%s") `+
+			`ndp_conn = from(bucket:"%s") `+
 			`|> range(start:%s, stop:%s) `+
-			`|> filter(fn:(r) => r._measurement == "redis" and r._field == "uptime_in_seconds" and r._cluster_id == "%s") `+
+			`|> filter(fn:(r) => r._measurement == "redis" and r._field == "total_connections_received" and r._cluster_id == "%s") `+
 			`|> keep(columns:["_start", "_stop", "_time", "_value", "hostname"]) `+
 			`|> map(fn: (r) => ({_time:r._time,_start:r._start,_stop:r._stop,_time:r._time,_value:float(v:r._value),hostname:r.hostname})) `+
 			`|> group(columns: ["hostname"]) `+

--- a/bulk_query_gen/influxdb/influx_dashboard_http_request_duration.go
+++ b/bulk_query_gen/influxdb/influx_dashboard_http_request_duration.go
@@ -1,6 +1,8 @@
 package influxdb
 
-import "time"
+import (
+	"time"
+)
 import (
 	"fmt"
 	bulkQuerygen "github.com/influxdata/influxdb-comparisons/bulk_query_gen"
@@ -30,7 +32,43 @@ func (d *InfluxDashboardHttpRequestDuration) Dispatch(i int) bulkQuerygen.Query 
 
 	var query string
 	//SELECT non_negative_derivative(percentile("writeReqDurationNs", 99)) /  non_negative_derivative(max(writeReq)) FROM "telegraf"."default"."influxdb_httpd" WHERE "cluster_id" = :Cluster_Id: AND time > :dashboardTime: GROUP BY host, time(1m)
-	query = fmt.Sprintf("SELECT non_negative_derivative(percentile(\"uptime_in_seconds\", 99)) / non_negative_derivative(max(total_connections_received)) FROM redis WHERE cluster_id = '%s' and %s group by hostname, time(1m)", d.GetRandomClusterId(), d.GetTimeConstraint(interval))
+	if d.language == InfluxQL {
+		query = fmt.Sprintf("SELECT non_negative_derivative(percentile(\"uptime_in_seconds\", 99)) / non_negative_derivative(max(total_connections_received)) FROM redis WHERE cluster_id = '%s' and %s group by hostname, time(1m)", d.GetRandomClusterId(), d.GetTimeConstraint(interval))
+	} else {
+		query = fmt.Sprintf(`ndp_uptime = from(bucket:"%s") `+
+			`|> range(start:%s, stop:%s) `+
+			`|> filter(fn:(r) => r._measurement == "redis" and r._field == "uptime_in_seconds" and r_cluster_id == "%s") `+
+			`|> keep(columns:["_start", "_stop", "_time", "_value", "hostname"]) `+
+			`|> map(fn: (r) => ({_time:r._time,_start:r._start,_stop:r._stop,_time:r._time,_value:float(v:r._value),hostname:r.hostname})) `+
+			`|> group(columns: ["hostname"]) `+
+			`|> window(every: 1m) `+
+			`|> quantile(q: 0.99, method: "estimate_tdigest") `+
+			`|> duplicate(column: "_stop", as: "_time") `+
+			`|> window(every: inf) `+
+			`|> derivative(nonNegative: true)\n`+
+			`ndp_uptime = from(bucket:"%s") `+
+			`|> range(start:%s, stop:%s) `+
+			`|> filter(fn:(r) => r._measurement == "redis" and r._field == "uptime_in_seconds" and r_cluster_id == "%s") `+
+			`|> keep(columns:["_start", "_stop", "_time", "_value", "hostname"]) `+
+			`|> map(fn: (r) => ({_time:r._time,_start:r._start,_stop:r._stop,_time:r._time,_value:float(v:r._value),hostname:r.hostname})) `+
+			`|> group(columns: ["hostname"]) `+
+			`|> window(every: 1m) `+
+			`|> max() `+
+			`|> drop(columns: ["_time"]) `+
+			`|> duplicate(column: "_stop", as: "_time") `+
+			`|> window(every: inf) `+
+			`|> derivative(nonNegative: true)\n`+
+			`join(tables:{ndp_uptime:ndp_uptime,ndm_conn:ndm_conn},on: ["_time","hostname"]) `+
+			`|> map(fn: (r) => ({_time:r._time,_value:(r._value_ndp_uptime / r._value_ndm_conn)})) `+
+			`|> keep(columns:["_time", "_value"]) `+
+			`|> yield()`,
+			d.DatabaseName,
+			interval.StartString(), interval.EndString(),
+			d.GetRandomClusterId(),
+			d.DatabaseName,
+			interval.StartString(), interval.EndString(),
+			d.GetRandomClusterId())
+	}
 
 	humanLabel := fmt.Sprintf("InfluxDB (%s) HTTP Request Duration (99th %%), rand cluster, %s by host, 1m", d.language.String(), interval.Duration())
 

--- a/bulk_query_gen/influxdb/influx_dashboard_http_requests.go
+++ b/bulk_query_gen/influxdb/influx_dashboard_http_requests.go
@@ -30,7 +30,22 @@ func (d *InfluxDashboardHttpRequests) Dispatch(i int) bulkQuerygen.Query {
 
 	var query string
 	//SELECT non_negative_derivative(mean("queryReq"), 10s) FROM "telegraf"."default"."influxdb_httpd" WHERE "cluster_id" = :Cluster_Id: AND time > :dashboardTime: GROUP BY time(1m), "host"
-	query = fmt.Sprintf("SELECT non_negative_derivative(mean(\"requests\"), 10s) FROM nginx WHERE cluster_id = '%s' and %s group by time(1m), \"hostname\"", d.GetRandomClusterId(), d.GetTimeConstraint(interval))
+	if d.language == InfluxQL {
+		query = fmt.Sprintf("SELECT non_negative_derivative(mean(\"requests\"), 10s) FROM nginx WHERE cluster_id = '%s' and %s group by time(1m), \"hostname\"", d.GetRandomClusterId(), d.GetTimeConstraint(interval))
+	} else {
+		query = fmt.Sprintf(`from(bucket:"%s") `+
+			`|> range(start:%s, stop:%s) `+
+			`|> filter(fn:(r) => r._measurement == "nginx" and r._field == "requests" and r.cluster_id == "%s") `+
+			`|> keep(columns:["_start", "_stop", "_time", "_value", "hostname"]) `+
+			`|> group(columns: ["hostname"]) `+
+			`|> aggregateWindow(every: 1m, fn: mean, createEmpty: false) `+
+			`|> derivative(unit: 10s, nonNegative: true) `+
+			`|> keep(columns: ["_time", "_value", "hostname"]) `+
+			`|> yield()`,
+			d.DatabaseName,
+			interval.StartString(), interval.EndString(),
+			d.GetRandomClusterId())
+	}
 
 	humanLabel := fmt.Sprintf("InfluxDB (%s) HTTP Requests/Min (Number), rand cluster, %s by 1m, host", d.language.String(), interval.Duration())
 

--- a/bulk_query_gen/influxdb/influx_dashboard_kapa_load.go
+++ b/bulk_query_gen/influxdb/influx_dashboard_kapa_load.go
@@ -36,17 +36,17 @@ func (d *InfluxDashboardKapaLoad) Dispatch(i int) bulkQuerygen.Query {
 		query = fmt.Sprintf(`load5 = from(bucket:"%s") `+ // TODO join 3 tables when it is supported?
 			`|> range(start:%s, stop:%s) `+
 			`|> filter(fn:(r) => r._measurement == "system" and r._field == "load5" and r.hostname == "kapacitor_1") `+
-			`|> keep(columns:["_time", "_value"])\n`+
+			`|> keep(columns:["_time", "_value"])`+"\n"+
 			`load15 = from(bucket:"%s") `+
 			`|> range(start:%s, stop:%s) `+
 			`|> filter(fn:(r) => r._measurement == "system" and r._field == "load15" and r.hostname == "kapacitor_1") `+
-			`|> keep(columns:["_time", "_value"])\n`+
+			`|> keep(columns:["_time", "_value"])`+"\n"+
 			`load1 = from(bucket:"%s") `+
 			`|> range(start:%s, stop:%s) `+
 			`|> filter(fn:(r) => r._measurement == "system" and r._field == "load1" and r.hostname == "kapacitor_1") `+
-			`|> keep(columns:["_time", "_value"])\n`+
-			`load5 |> yield(name: "load5")\n` +
-			`load15 |> yield(name: "load15")\n` +
+			`|> keep(columns:["_time", "_value"])`+"\n"+
+			`load5 |> yield(name: "load5")`+"\n"+
+			`load15 |> yield(name: "load15")`+"\n"+
 			`load1 |> yield(name: "load1")`,
 			d.DatabaseName,
 			interval.StartString(), interval.EndString(),

--- a/bulk_query_gen/influxdb/influx_dashboard_kapa_load.go
+++ b/bulk_query_gen/influxdb/influx_dashboard_kapa_load.go
@@ -33,21 +33,21 @@ func (d *InfluxDashboardKapaLoad) Dispatch(i int) bulkQuerygen.Query {
 	if d.language == InfluxQL {
 		query = fmt.Sprintf("SELECT \"load5\", \"load15\", \"load1\" FROM system WHERE hostname='kapacitor_1' and %s", d.GetTimeConstraint(interval))
 	} else {
-		query = fmt.Sprintf(`from(bucket:"%s") `+ // TODO join 3 tables when it is supported?
+		query = fmt.Sprintf(`load5 = from(bucket:"%s") `+ // TODO join 3 tables when it is supported?
 			`|> range(start:%s, stop:%s) `+
 			`|> filter(fn:(r) => r._measurement == "system" and r._field == "load5" and r.hostname == "kapacitor_1") `+
-			`|> keep(columns:["_time", "_value"]) `+
-			`|> yield(name: "load5")\n` +
-			`from(bucket:"%s") `+
+			`|> keep(columns:["_time", "_value"])\n`+
+			`load15 = from(bucket:"%s") `+
 			`|> range(start:%s, stop:%s) `+
 			`|> filter(fn:(r) => r._measurement == "system" and r._field == "load15" and r.hostname == "kapacitor_1") `+
-			`|> keep(columns:["_time", "_value"]) `+
-			`|> yield(name: "load15")\n` +
-			`from(bucket:"%s") `+
+			`|> keep(columns:["_time", "_value"])\n`+
+			`load1 = from(bucket:"%s") `+
 			`|> range(start:%s, stop:%s) `+
 			`|> filter(fn:(r) => r._measurement == "system" and r._field == "load1" and r.hostname == "kapacitor_1") `+
-			`|> keep(columns:["_time", "_value"]) `+
-			`|> yield(name: "load1")\n`,
+			`|> keep(columns:["_time", "_value"])\n`+
+			`load5 |> yield(name: "load5")\n` +
+			`load15 |> yield(name: "load15")\n` +
+			`load1 |> yield(name: "load1")`,
 			d.DatabaseName,
 			interval.StartString(), interval.EndString(),
 			d.DatabaseName,

--- a/bulk_query_gen/influxdb/influx_dashboard_kapa_load.go
+++ b/bulk_query_gen/influxdb/influx_dashboard_kapa_load.go
@@ -30,7 +30,31 @@ func (d *InfluxDashboardKapaLoad) Dispatch(i int) bulkQuerygen.Query {
 
 	var query string
 	//SELECT "load5", "load15", "load1" FROM "telegraf"."autogen"."system" WHERE time > :dashboardTime: AND "host"='kapacitor'
-	query = fmt.Sprintf("SELECT \"load5\", \"load15\", \"load1\" FROM system WHERE hostname='kapacitor_1' and %s", d.GetTimeConstraint(interval))
+	if d.language == InfluxQL {
+		query = fmt.Sprintf("SELECT \"load5\", \"load15\", \"load1\" FROM system WHERE hostname='kapacitor_1' and %s", d.GetTimeConstraint(interval))
+	} else {
+		query = fmt.Sprintf(`from(bucket:"%s") `+ // TODO join 3 tables when it is supported?
+			`|> range(start:%s, stop:%s) `+
+			`|> filter(fn:(r) => r._measurement == "system" and r._field == "load5" and r.hostname == "kapacitor_1") `+
+			`|> keep(columns:["_time", "_value"]) `+
+			`|> yield(name: "load5")\n` +
+			`from(bucket:"%s") `+
+			`|> range(start:%s, stop:%s) `+
+			`|> filter(fn:(r) => r._measurement == "system" and r._field == "load15" and r.hostname == "kapacitor_1") `+
+			`|> keep(columns:["_time", "_value"]) `+
+			`|> yield(name: "load15")\n` +
+			`from(bucket:"%s") `+
+			`|> range(start:%s, stop:%s) `+
+			`|> filter(fn:(r) => r._measurement == "system" and r._field == "load1" and r.hostname == "kapacitor_1") `+
+			`|> keep(columns:["_time", "_value"]) `+
+			`|> yield(name: "load1")\n`,
+			d.DatabaseName,
+			interval.StartString(), interval.EndString(),
+			d.DatabaseName,
+			interval.StartString(), interval.EndString(),
+			d.DatabaseName,
+			interval.StartString(), interval.EndString())
+	}
 
 	humanLabel := fmt.Sprintf("InfluxDB (%s) kapa load 1,5,15 in %s", d.language.String(), interval.Duration())
 

--- a/bulk_query_gen/influxdb/influx_dashboard_memory_total.go
+++ b/bulk_query_gen/influxdb/influx_dashboard_memory_total.go
@@ -38,9 +38,7 @@ func (d *InfluxDashboardMemoryTotal) Dispatch(i int) bulkQuerygen.Query {
 			`|> filter(fn:(r) => r._measurement == "mem" and r._field == "total" and r._cluster_id == "%s" and r.hostname =~ /data/) `+
 			`|> keep(columns:["_start", "_stop", "_time", "_value"]) `+
 			`|> group(columns: ["hostname"]) `+
-			`|> window(every: 1m) `+ // TODO replace window-max-window with aggregateWindow(every: 1m, fn: max) when it works
-			`|> max() `+
-			`|> window(every: inf) `+
+			`|> aggregateWindow(every: 1m, fn: max, createEmpty: false) `+
 			`|> map(fn: (r) => ({_time:r._time, _value:r._value / 1073741824})) `+
 			`|> group() `+ // or add 'group by hostname' to InfluxQL to return last max for each host
 			`|> last() `+

--- a/bulk_query_gen/influxdb/influx_dashboard_memory_total.go
+++ b/bulk_query_gen/influxdb/influx_dashboard_memory_total.go
@@ -35,7 +35,7 @@ func (d *InfluxDashboardMemoryTotal) Dispatch(i int) bulkQuerygen.Query {
 	} else {
 		query = fmt.Sprintf(`from(bucket:"%s") `+
 			`|> range(start:%s, stop:%s) `+
-			`|> filter(fn:(r) => r._measurement == "mem" and r._field == "total" and r._cluster_id == "%s" and hostname =~ /data/) `+
+			`|> filter(fn:(r) => r._measurement == "mem" and r._field == "total" and r._cluster_id == "%s" and r.hostname =~ /data/) `+
 			`|> keep(columns:["_start", "_stop", "_time", "_value"]) `+
 			`|> group(columns: ["hostname"]) `+
 			`|> window(every: 1m) `+ // TODO replace window-max-window with aggregateWindow(every: 1m, fn: max) when it works

--- a/bulk_query_gen/influxdb/influx_dashboard_memory_total.go
+++ b/bulk_query_gen/influxdb/influx_dashboard_memory_total.go
@@ -30,7 +30,26 @@ func (d *InfluxDashboardMemoryTotal) Dispatch(i int) bulkQuerygen.Query {
 
 	var query string
 	//SELECT last("max") from (SELECT max("total")/1073741824 FROM "telegraf"."default"."mem" WHERE "cluster_id" = :Cluster_Id: AND time > :dashboardTime: and host =~ /.data./ GROUP BY time(1m), host)
-	query = fmt.Sprintf("SELECT last(\"max\") from (SELECT max(\"total\")/1073741824 FROM mem WHERE cluster_id = '%s' and %s and hostname =~ /data/  group by time(1m), hostname)", d.GetRandomClusterId(), d.GetTimeConstraint(interval))
+	if d.language == InfluxQL {
+		query = fmt.Sprintf("SELECT last(\"max\") from (SELECT max(\"total\")/1073741824 FROM mem WHERE cluster_id = '%s' and %s and hostname =~ /data/  group by time(1m), hostname)", d.GetRandomClusterId(), d.GetTimeConstraint(interval))
+	} else {
+		query = fmt.Sprintf(`from(bucket:"%s") `+
+			`|> range(start:%s, stop:%s) `+
+			`|> filter(fn:(r) => r._measurement == "mem" and r._field == "total" and r_cluster_id == "%s" and hostname =~ /data/) `+
+			`|> keep(columns:["_start", "_stop", "_time", "_value"]) `+
+			`|> group(columns: ["hostname"]) `+
+			`|> window(every: 1m) `+ // TODO replace window-max-window with aggregateWindow(every: 1m, fn: max) when it works
+			`|> max() `+
+			`|> window(every: inf) `+
+			`|> map(fn: (r) => ({_time:r._time, _value:r._value / 1073741824})) `+
+			`|> group() `+ // or add 'group by hostname' to InfluxQL to return last max for each host
+			`|> last() `+
+			`|> keep(columns: ["_time", "_value"]) `+
+			`|> yield()`,
+			d.DatabaseName,
+			interval.StartString(), interval.EndString(),
+			d.GetRandomClusterId())
+	}
 
 	humanLabel := fmt.Sprintf("InfluxDB (%s) Memory (MB), rand cluster, %s by 1m", d.language.String(), interval.Duration())
 

--- a/bulk_query_gen/influxdb/influx_dashboard_memory_total.go
+++ b/bulk_query_gen/influxdb/influx_dashboard_memory_total.go
@@ -35,7 +35,7 @@ func (d *InfluxDashboardMemoryTotal) Dispatch(i int) bulkQuerygen.Query {
 	} else {
 		query = fmt.Sprintf(`from(bucket:"%s") `+
 			`|> range(start:%s, stop:%s) `+
-			`|> filter(fn:(r) => r._measurement == "mem" and r._field == "total" and r_cluster_id == "%s" and hostname =~ /data/) `+
+			`|> filter(fn:(r) => r._measurement == "mem" and r._field == "total" and r._cluster_id == "%s" and hostname =~ /data/) `+
 			`|> keep(columns:["_start", "_stop", "_time", "_value"]) `+
 			`|> group(columns: ["hostname"]) `+
 			`|> window(every: 1m) `+ // TODO replace window-max-window with aggregateWindow(every: 1m, fn: max) when it works

--- a/bulk_query_gen/influxdb/influx_dashboard_memory_utilization.go
+++ b/bulk_query_gen/influxdb/influx_dashboard_memory_utilization.go
@@ -35,7 +35,7 @@ func (d *InfluxDashboardMemoryUtilization) Dispatch(i int) bulkQuerygen.Query {
 	} else {
 		query = fmt.Sprintf(`from(bucket:"%s") `+
 			`|> range(start:%s, stop:%s) `+
-			`|> filter(fn:(r) => r._measurement == "mem" and r._field == "used_percent" and r_cluster_id == "%s") `+
+			`|> filter(fn:(r) => r._measurement == "mem" and r._field == "used_percent" and r._cluster_id == "%s") `+
 			`|> keep(columns:["_start", "_stop", "_time", "_value", "hostname"]) `+
 			`|> group(columns:["hostname"]) `+
 			`|> aggregateWindow(every: 1m, fn: mean, createEmpty: false) ` +

--- a/bulk_query_gen/influxdb/influx_dashboard_memory_utilization.go
+++ b/bulk_query_gen/influxdb/influx_dashboard_memory_utilization.go
@@ -30,7 +30,21 @@ func (d *InfluxDashboardMemoryUtilization) Dispatch(i int) bulkQuerygen.Query {
 
 	var query string
 	//SELECT mean("used_percent") FROM "telegraf"."default"."mem" WHERE "cluster_id" = :Cluster_Id: AND time > :dashboardTime: GROUP BY time(1m), "host"
-	query = fmt.Sprintf("SELECT mean(\"used_percent\") FROM mem WHERE cluster_id = '%s' and %s group by time(1m), hostname", d.GetRandomClusterId(), d.GetTimeConstraint(interval))
+	if d.language == InfluxQL {
+		query = fmt.Sprintf("SELECT mean(\"used_percent\") FROM mem WHERE cluster_id = '%s' and %s group by time(1m), hostname", d.GetRandomClusterId(), d.GetTimeConstraint(interval))
+	} else {
+		query = fmt.Sprintf(`from(bucket:"%s") `+
+			`|> range(start:%s, stop:%s) `+
+			`|> filter(fn:(r) => r._measurement == "mem" and r._field == "used_percent" and r_cluster_id == "%s") `+
+			`|> keep(columns:["_start", "_stop", "_time", "_value", "hostname"]) `+
+			`|> group(columns:["hostname"]) `+
+			`|> aggregateWindow(every: 1m, fn: mean, createEmpty: false) ` +
+			`|> keep(columns: ["_time", "_value", "hostname"]) `+
+			`|> yield()`,
+			d.DatabaseName,
+			interval.StartString(), interval.EndString(),
+			d.GetRandomClusterId())
+	}
 
 	humanLabel := fmt.Sprintf("InfluxDB (%s) Memory Utilization (Percent), rand cluster, %s by 1m", d.language.String(), interval.Duration())
 

--- a/bulk_query_gen/influxdb/influx_dashboard_nginx_requests.go
+++ b/bulk_query_gen/influxdb/influx_dashboard_nginx_requests.go
@@ -30,7 +30,22 @@ func (d *InfluxDashboardNginxRequests) Dispatch(i int) bulkQuerygen.Query {
 
 	var query string
 	//SELECT non_negative_derivative(mean("queriesExecuted"), 1s) FROM "telegraf"."default"."influxdb_queryExecutor" WHERE "cluster_id" = :Cluster_Id: AND time > :dashboardTime: GROUP BY time(1m), "host"
-	query = fmt.Sprintf("SELECT non_negative_derivative(mean(\"accepts\"), 1s) FROM nginx WHERE cluster_id = '%s' and %s group by time(1m), \"hostname\"", d.GetRandomClusterId(), d.GetTimeConstraint(interval))
+	if d.language == InfluxQL {
+		query = fmt.Sprintf("SELECT non_negative_derivative(mean(\"accepts\"), 1s) FROM nginx WHERE cluster_id = '%s' and %s group by time(1m), \"hostname\"", d.GetRandomClusterId(), d.GetTimeConstraint(interval))
+	} else {
+		query = fmt.Sprintf(`from(bucket:"%s") `+
+			`|> range(start:%s, stop:%s) `+
+			`|> filter(fn:(r) => r._measurement == "nginx" and r._field == "accepts" and r.cluster_id == "%s") `+
+			`|> keep(columns:["_start", "_stop", "_time", "_value", "hostname"]) `+
+			`|> group(columns: ["hostname"]) `+
+			`|> aggregateWindow(every: 1m, fn: mean, createEmpty: false) `+
+			`|> derivative(unit: 1s, nonNegative: true) `+
+			`|> keep(columns: ["_time", "_value", "hostname"]) `+
+			`|> yield()`,
+			d.DatabaseName,
+			interval.StartString(), interval.EndString(),
+			d.GetRandomClusterId())
+	}
 
 	humanLabel := fmt.Sprintf("InfluxDB (%s) Queries Executed (Number)	, rand cluster, %s by 1m, host", d.language.String(), interval.Duration())
 

--- a/bulk_query_gen/influxdb/influx_dashboard_queue_bytes.go
+++ b/bulk_query_gen/influxdb/influx_dashboard_queue_bytes.go
@@ -38,7 +38,8 @@ func (d *InfluxDashboardQueueBytes) Dispatch(i int) bulkQuerygen.Query {
 			`|> filter(fn:(r) => r._measurement == "postgresl" and r._field == "temp_files" and r.cluster_id == "%s") `+
 			`|> keep(columns:["_start", "_stop", "_time", "_value", "hostname"]) `+
 			`|> group(columns: ["hostname"]) `+
-			`|> aggregateWindow(every: 1m, fn: mean, createEmpty: true) `+ // createEmpty: true == fill(0)???
+			`|> aggregateWindow(every: 1m, fn: mean, createEmpty: true) `+
+			`|> fill(value: 0.0) `+
 			`|> keep(columns: ["_time", "_value", "hostname"]) `+
 			`|> yield()`,
 			d.DatabaseName,

--- a/bulk_query_gen/influxdb/influx_dashboard_queue_bytes.go
+++ b/bulk_query_gen/influxdb/influx_dashboard_queue_bytes.go
@@ -30,7 +30,21 @@ func (d *InfluxDashboardQueueBytes) Dispatch(i int) bulkQuerygen.Query {
 
 	var query string
 	//SELECT mean("queueBytes") FROM "telegraf"."default"."influxdb_hh_processor" WHERE "cluster_id" = :Cluster_Id: AND time > :dashboardTime: GROUP BY time(1m), "host" fill(0)
-	query = fmt.Sprintf("SELECT mean(\"temp_files\") FROM postgresl WHERE cluster_id = '%s' and %s group by time(1m), hostname, fill(0)", d.GetRandomClusterId(), d.GetTimeConstraint(interval))
+	if d.language == InfluxQL {
+		query = fmt.Sprintf("SELECT mean(\"temp_files\") FROM postgresl WHERE cluster_id = '%s' and %s group by time(1m), hostname, fill(0)", d.GetRandomClusterId(), d.GetTimeConstraint(interval))
+	} else {
+		query = fmt.Sprintf(`from(bucket:"%s") `+
+			`|> range(start:%s, stop:%s) `+
+			`|> filter(fn:(r) => r._measurement == "postgresl" and r._field == "temp_files" and r.cluster_id == "%s") `+
+			`|> keep(columns:["_start", "_stop", "_time", "_value", "hostname"]) `+
+			`|> group(columns: ["hostname"]) `+
+			`|> aggregateWindow(every: 1m, fn: mean, createEmpty: true) `+ // createEmpty: true == fill(0)???
+			`|> keep(columns: ["_time", "_value", "hostname"]) `+
+			`|> yield()`,
+			d.DatabaseName,
+			interval.StartString(), interval.EndString(),
+			d.GetRandomClusterId())
+	}
 
 	humanLabel := fmt.Sprintf("InfluxDB (%s) Hinted HandOff Queue Size (MB), rand cluster, %s by 1m", d.language.String(), interval.Duration())
 

--- a/bulk_query_gen/influxdb/influx_dashboard_redis_memory_utilization.go
+++ b/bulk_query_gen/influxdb/influx_dashboard_redis_memory_utilization.go
@@ -32,13 +32,14 @@ func (d *InfluxDashboardRedisMemoryUtilization) Dispatch(i int) bulkQuerygen.Que
 	//SELECT mean("usage_percent") FROM "telegraf"."default"."docker_container_mem" WHERE "cluster_id" = :Cluster_Id: AND ("container_name" =~ /influxd.*/ OR "container_name" =~ /kap.*/) AND time > :dashboardTime: GROUP BY time(1m), "host", "container_name" fill(previous)
 	if d.language == InfluxQL {
 		query = fmt.Sprintf("SELECT mean(\"used_memory\") FROM redis WHERE cluster_id = '%s' and %s group by time(1m),hostname, server fill(previous)", d.GetRandomClusterId(), d.GetTimeConstraint(interval))
-	} else { // TODO fill(previous)???
+	} else {
 		query = fmt.Sprintf(`from(bucket:"%s") `+
 			`|> range(start:%s, stop:%s) `+
 			`|> filter(fn:(r) => r._measurement == "redis" and r._field == "used_memory" and r.cluster_id == "%s") `+
 			`|> keep(columns:["_start", "_stop", "_time", "_value", "hostname", "server"]) `+
 			`|> group(columns: ["hostname", "server"]) `+
-			`|> aggregateWindow(every: 1m, fn: mean, createEmpty: false) `+
+			`|> aggregateWindow(every: 1m, fn: mean, createEmpty: true) `+
+			`|> fill(usePrevious: true) `+
 			`|> keep(columns: ["_time", "_value", "hostname", "server"]) `+
 			`|> yield()`,
 			d.DatabaseName,

--- a/bulk_query_gen/influxdb/influx_dashboard_system_load.go
+++ b/bulk_query_gen/influxdb/influx_dashboard_system_load.go
@@ -37,22 +37,14 @@ func (d *InfluxDashboardSystemLoad) Dispatch(i int) bulkQuerygen.Query {
 			`|> range(start:%s, stop:%s) `+
 			`|> filter(fn:(r) => r._measurement == "system" and r._field == "load5" and r.cluster_id == "%s") `+
 			`|> keep(columns:["_start", "_stop", "_time", "_value", "hostname"]) `+
-			`|> window(every: 1m) `+ // TODO replace with aggregateWindow when it is fixed
-			`|> max() `+
-			`|> drop(columns: ["_time"]) `+
-			`|> duplicate(column: "_stop", as: "_time") `+
-			`|> window(every: inf) `+
+			`|> aggregateWindow(every: 1m, fn: max, createEmpty: false) `+
 			`|> group(columns: ["hostname"])  `+
 			`|> keep(columns:["_time", "_value", "hostname"])`+"\n"+
 			`max_ncpus = from(bucket:"%s") `+
 			`|> range(start:%s, stop:%s) `+
 			`|> filter(fn:(r) => r._measurement == "system" and r._field == "n_cpus" and r.cluster_id == "%s") `+
 			`|> keep(columns:["_start", "_stop", "_time", "_value", "hostname"]) `+
-			`|> window(every: 1m) `+ // TODO replace with aggregateWindow when it is fixed
-			`|> max() `+
-			`|> drop(columns: ["_time"]) `+
-			`|> duplicate(column: "_stop", as: "_time") `+
-			`|> window(every: inf) `+
+			`|> aggregateWindow(every: 1m, fn: max, createEmpty: false) `+
 			`|> group(columns: ["hostname"])  `+
 			`|> keep(columns:["_time", "_value", "hostname"])`+"\n"+
 			`join(tables: {max_load_5:max_load5,max_ncpus:max_ncpus},on: ["_time", "hostname"]) `+

--- a/bulk_query_gen/influxdb/influx_dashboard_system_load.go
+++ b/bulk_query_gen/influxdb/influx_dashboard_system_load.go
@@ -43,7 +43,7 @@ func (d *InfluxDashboardSystemLoad) Dispatch(i int) bulkQuerygen.Query {
 			`|> duplicate(column: "_stop", as: "_time") `+
 			`|> window(every: inf) `+
 			`|> group(columns: ["hostname"])  `+
-			`|> keep(columns:["_time", "_value", "hostname"])\n`+
+			`|> keep(columns:["_time", "_value", "hostname"])`+"\n"+
 			`max_ncpus = from(bucket:"%s") `+
 			`|> range(start:%s, stop:%s) `+
 			`|> filter(fn:(r) => r._measurement == "system" and r._field == "n_cpus" and r.cluster_id == "%s") `+
@@ -54,7 +54,7 @@ func (d *InfluxDashboardSystemLoad) Dispatch(i int) bulkQuerygen.Query {
 			`|> duplicate(column: "_stop", as: "_time") `+
 			`|> window(every: inf) `+
 			`|> group(columns: ["hostname"])  `+
-			`|> keep(columns:["_time", "_value", "hostname"])\n`+
+			`|> keep(columns:["_time", "_value", "hostname"])`+"\n"+
 			`join(tables: {max_load_5:max_load5,max_ncpus:max_ncpus},on: ["_time", "hostname"]) `+
 			`|> keep(columns: ["_time", "_value_max_load5", "_value_max_ncpus", "hostname"]) `+
 			`|> yield()`,

--- a/bulk_query_gen/influxdb/influx_dashboard_throughput.go
+++ b/bulk_query_gen/influxdb/influx_dashboard_throughput.go
@@ -38,9 +38,7 @@ func (d *InfluxDashboardThroughput) Dispatch(i int) bulkQuerygen.Query {
 			`|> filter(fn:(r) => r._measurement == "redis" and r._field == "keyspace_hits" and r.cluster_id == "%s") `+
 			`|> keep(columns:["_start", "_stop", "_time", "_value", "hostname"]) `+
 			`|> group(columns: ["hostname"]) `+
-			`|> window(every: 1m) `+ // TODO replace with aggregateWindow when it is fixed
-			`|> max() `+
-			`|> window(every: inf) `+
+			`|> aggregateWindow(every: 1m, fn: max, createEmpty: false) `+
 			`|> derivative(unit: 10s, nonNegative: true) `+
 			`|> keep(columns: ["_time", "_value", "hostname"]) `+
 			`|> yield()`,

--- a/bulk_query_gen/influxdb/influx_dashboard_throughput.go
+++ b/bulk_query_gen/influxdb/influx_dashboard_throughput.go
@@ -30,7 +30,24 @@ func (d *InfluxDashboardThroughput) Dispatch(i int) bulkQuerygen.Query {
 
 	var query string
 	//SELECT non_negative_derivative(max("pointReqLocal"), 10s) FROM "telegraf"."default"."influxdb_write" WHERE "cluster_id" = :Cluster_Id: AND time > :dashboardTime: GROUP BY time(1m), "host"
-	query = fmt.Sprintf("SELECT non_negative_derivative(max(\"keyspace_hits\"), 10s) FROM redis WHERE cluster_id = '%s' and %s group by time(1m), \"hostname\"", d.GetRandomClusterId(), d.GetTimeConstraint(interval))
+	if d.language == InfluxQL {
+		query = fmt.Sprintf("SELECT non_negative_derivative(max(\"keyspace_hits\"), 10s) FROM redis WHERE cluster_id = '%s' and %s group by time(1m), \"hostname\"", d.GetRandomClusterId(), d.GetTimeConstraint(interval))
+	} else {
+		query = fmt.Sprintf(`from(bucket:"%s") `+
+			`|> range(start:%s, stop:%s) `+
+			`|> filter(fn:(r) => r._measurement == "redis" and r._field == "keyspace_hits" and r.cluster_id == "%s") `+
+			`|> keep(columns:["_start", "_stop", "_time", "_value", "hostname"]) `+
+			`|> group(columns: ["hostname"]) `+
+			`|> window(every: 1m) `+ // TODO replace with aggregateWindow when it is fixed
+			`|> max() `+
+			`|> window(every: inf) `+
+			`|> derivative(unit: 10s, nonNegative: true) `+
+			`|> keep(columns: ["_time", "_value", "hostname"]) `+
+			`|> yield()`,
+			d.DatabaseName,
+			interval.StartString(), interval.EndString(),
+			d.GetRandomClusterId())
+	}
 
 	humanLabel := fmt.Sprintf("InfluxDB (%s) Per-Host Point Throughput (Number), %s by 1m", d.language.String(), interval.Duration())
 

--- a/bulk_query_gen/influxdb/influx_devops_common.go
+++ b/bulk_query_gen/influxdb/influx_devops_common.go
@@ -116,7 +116,8 @@ func (d *InfluxDevops) MeanCPUUsageDayByHourAllHostsGroupbyHost(qi bulkQuerygen.
 			`|> range(start:%s, stop:%s) `+
 			`|> filter(fn:(r) => r._measurement == "cpu" and r._field == "usage_user") `+
 			`|> group(columns: ["hostname"]) `+
-			`|> aggregateWindow(every: 1h, fn: mean) `+
+			`|> mean() `+
+//			`|> aggregateWindow(every: 1h, fn: mean) `+
 			`|> yield()`,
 			d.DatabaseName,
 			interval.StartString(), interval.EndString())

--- a/bulk_query_gen/influxdb/influx_devops_common.go
+++ b/bulk_query_gen/influxdb/influx_devops_common.go
@@ -115,10 +115,8 @@ func (d *InfluxDevops) MeanCPUUsageDayByHourAllHostsGroupbyHost(qi bulkQuerygen.
 		query = fmt.Sprintf(`from(bucket:"%s") `+
 			`|> range(start:%s, stop:%s) `+
 			`|> filter(fn:(r) => r._measurement == "cpu" and r._field == "usage_user") `+
-			`|> keep(columns:["_start", "_stop", "_time", "_value", "hostname"]) `+
+			`|> group(columns: ["hostname"]) `+
 			`|> aggregateWindow(every: 1h, fn: mean) `+
-			`|> group(by:["hostname"]) `+
-			`|> keep(columns:["_time", "_value", "hostname"]) `+
 			`|> yield()`,
 			d.DatabaseName,
 			interval.StartString(), interval.EndString())

--- a/bulk_query_gen/influxdb/influx_devops_common.go
+++ b/bulk_query_gen/influxdb/influx_devops_common.go
@@ -90,8 +90,10 @@ func (d *InfluxDevops) maxCPUUsageHourByMinuteNHosts(qi bulkQuerygen.Query, nhos
 			`|> range(start:%s, stop:%s) `+
 			`|> filter(fn:(r) => r._measurement == "cpu" and r._field == "usage_user" and (%s)) `+
 			`|> keep(columns:["_start", "_stop", "_time", "_value"]) `+
-			`|> window(period:1m) `+
+			`|> window(every: 1m) `+ // TODO replace with aggregateWindow when it is fixed
 			`|> max() `+
+			`|> window(every: inf) `+
+			`|> keep(columns:["_time", "_value", "hostname"]) `+
 			`|> yield()`,
 			d.DatabaseName,
 			interval.StartString(), interval.EndString(),
@@ -116,11 +118,10 @@ func (d *InfluxDevops) MeanCPUUsageDayByHourAllHostsGroupbyHost(qi bulkQuerygen.
 		query = fmt.Sprintf(`from(bucket:"%s") `+
 			`|> range(start:%s, stop:%s) `+
 			`|> filter(fn:(r) => r._measurement == "cpu" and r._field == "usage_user") `+
-			`|> keep(columns:["_start", "_stop", "hostname", "_value", "_time"]) `+
-			`|> window(every:1h) `+
-			`|> mean() `+
+			`|> keep(columns:["_start", "_stop", "_time", "_value", "hostname"]) `+
+			`|> aggregateWindow(every: 1h, fn: mean) `+
 			`|> group(by:["hostname"]) `+
-			`|> keep(columns:["_start", "hostname", "_value"]) `+
+			`|> keep(columns:["_time", "_value", "hostname"]) `+
 			`|> yield()`,
 			d.DatabaseName,
 			interval.StartString(), interval.EndString())
@@ -130,19 +131,3 @@ func (d *InfluxDevops) MeanCPUUsageDayByHourAllHostsGroupbyHost(qi bulkQuerygen.
 	q := qi.(*bulkQuerygen.HTTPQuery)
 	d.getHttpQuery(humanLabel, interval.StartString(), query, q)
 }
-
-//func (d *InfluxDevops) MeanCPUUsageDayByHourAllHostsGroupbyHost(qi Query, _ int) {
-//	interval := d.AllInterval.RandWindow(24*time.Hour)
-//
-//	v := url.Values{}
-//	v.Set("db", d.DatabaseName)
-//	v.Set("q", fmt.Sprintf("SELECT count(usage_user) from cpu where time >= '%s' and time < '%s' group by time(1h)", interval.StartString(), interval.EndString()))
-//
-//	humanLabel := "Influx mean cpu, all hosts, rand 1day by 1hour"
-//	q := qi.(*bulkQuerygen.HTTPQuery)
-//	q.HumanLabel = []byte(humanLabel)
-//	q.HumanDescription = []byte(fmt.Sprintf("%s: %s", humanLabel, interval.StartString()))
-//	q.Method = []byte("GET")
-//	q.Path = []byte(fmt.Sprintf("/query?%s", v.Encode()))
-//	q.Body = nil
-//}

--- a/bulk_query_gen/influxdb/influx_devops_common.go
+++ b/bulk_query_gen/influxdb/influx_devops_common.go
@@ -92,7 +92,7 @@ func (d *InfluxDevops) maxCPUUsageHourByMinuteNHosts(qi bulkQuerygen.Query, nhos
 			//`|> keep(columns:["_start", "_stop", "_time", "_value"]) `+
 			`|> group() `+
 			`|> aggregateWindow(every: 1m, fn: max, createEmpty: false) `+
-			//`|> keep(columns:["_time", "_value"]) `+
+			`|> drop(columns:["_start", "_stop"]) `+
 			//`|> yield()`,
 			``,
 			d.DatabaseName,

--- a/bulk_query_gen/influxdb/influx_devops_common.go
+++ b/bulk_query_gen/influxdb/influx_devops_common.go
@@ -86,12 +86,11 @@ func (d *InfluxDevops) maxCPUUsageHourByMinuteNHosts(qi bulkQuerygen.Query, nhos
 	if d.language == InfluxQL {
 		query = fmt.Sprintf("SELECT max(usage_user) from cpu where (%s) and time >= '%s' and time < '%s' group by time(1m)", combinedHostnameClause, interval.StartString(), interval.EndString())
 	} else { // Flux
-		query = fmt.Sprintf(`from(bucket:"%s") `+
-			`|> range(start:%s, stop:%s) `+
+		query = fmt.Sprintf(`from(bucket: "%s") `+
+			`|> range(start: %s, stop: %s) `+
 			`|> filter(fn:(r) => r._measurement == "cpu" and r._field == "usage_user" and (%s)) `+
 			`|> group() `+
 			`|> aggregateWindow(every: 1m, fn: max) `+
-			`|> keep(columns: ["_time", "_field", "_value"]) `+
 			`|> yield()`,
 			d.DatabaseName,
 			interval.StartString(), interval.EndString(),
@@ -113,8 +112,8 @@ func (d *InfluxDevops) MeanCPUUsageDayByHourAllHostsGroupbyHost(qi bulkQuerygen.
 	if d.language == InfluxQL {
 		query = fmt.Sprintf("SELECT mean(usage_user) from cpu where time >= '%s' and time < '%s' group by time(1h),hostname", interval.StartString(), interval.EndString())
 	} else {
-		query = fmt.Sprintf(`from(bucket:"%s") `+
-			`|> range(start:%s, stop:%s) `+
+		query = fmt.Sprintf(`from(bucket: "%s") `+
+			`|> range(start: %s, stop: %s) `+
 			`|> filter(fn:(r) => r._measurement == "cpu" and r._field == "usage_user") `+
 			`|> group(columns: ["hostname"]) `+
 			`|> aggregateWindow(every: 1h, fn: mean) `+

--- a/bulk_query_gen/influxdb/influx_devops_common.go
+++ b/bulk_query_gen/influxdb/influx_devops_common.go
@@ -90,9 +90,7 @@ func (d *InfluxDevops) maxCPUUsageHourByMinuteNHosts(qi bulkQuerygen.Query, nhos
 			`|> range(start:%s, stop:%s) `+
 			`|> filter(fn:(r) => r._measurement == "cpu" and r._field == "usage_user" and (%s)) `+
 			`|> keep(columns:["_start", "_stop", "_time", "_value"]) `+
-			`|> window(every: 1m) `+ // TODO replace with aggregateWindow when it is fixed
-			`|> max() `+
-			`|> window(every: inf) `+
+			`|> aggregateWindow(every: 1m, fn: max, createEmpty: false) `+
 			`|> keep(columns:["_time", "_value"]) `+
 			`|> yield()`,
 			d.DatabaseName,

--- a/bulk_query_gen/influxdb/influx_devops_common.go
+++ b/bulk_query_gen/influxdb/influx_devops_common.go
@@ -89,12 +89,9 @@ func (d *InfluxDevops) maxCPUUsageHourByMinuteNHosts(qi bulkQuerygen.Query, nhos
 		query = fmt.Sprintf(`from(bucket:"%s") `+
 			`|> range(start:%s, stop:%s) `+
 			`|> filter(fn:(r) => r._measurement == "cpu" and r._field == "usage_user" and (%s)) `+
-			//`|> keep(columns:["_start", "_stop", "_time", "_value"]) `+
 			`|> group() `+
 			`|> aggregateWindow(every: 1m, fn: max, createEmpty: false) `+
-			`|> drop(columns:["_start", "_stop"]) `+
-			//`|> yield()`,
-			``,
+			`|> drop(columns:["_start", "_stop"])`,
 			d.DatabaseName,
 			interval.StartString(), interval.EndString(),
 			combinedHostnameClause)

--- a/bulk_query_gen/influxdb/influx_devops_common.go
+++ b/bulk_query_gen/influxdb/influx_devops_common.go
@@ -91,6 +91,7 @@ func (d *InfluxDevops) maxCPUUsageHourByMinuteNHosts(qi bulkQuerygen.Query, nhos
 			`|> filter(fn:(r) => r._measurement == "cpu" and r._field == "usage_user" and (%s)) `+
 			`|> group() `+
 			`|> aggregateWindow(every: 1m, fn: max) `+
+			`|> keep(columns: ["_time", "_field", "_value"]) `+
 			`|> yield()`,
 			d.DatabaseName,
 			interval.StartString(), interval.EndString(),
@@ -117,7 +118,6 @@ func (d *InfluxDevops) MeanCPUUsageDayByHourAllHostsGroupbyHost(qi bulkQuerygen.
 			`|> filter(fn:(r) => r._measurement == "cpu" and r._field == "usage_user") `+
 			`|> group(columns: ["hostname"]) `+
 			`|> aggregateWindow(every: 1h, fn: mean) `+
-			`|> keep(columns: ["_time", "_field", "_value", hostname"]) `+
 			`|> yield()`,
 			d.DatabaseName,
 			interval.StartString(), interval.EndString())

--- a/bulk_query_gen/influxdb/influx_devops_common.go
+++ b/bulk_query_gen/influxdb/influx_devops_common.go
@@ -116,8 +116,8 @@ func (d *InfluxDevops) MeanCPUUsageDayByHourAllHostsGroupbyHost(qi bulkQuerygen.
 			`|> range(start:%s, stop:%s) `+
 			`|> filter(fn:(r) => r._measurement == "cpu" and r._field == "usage_user") `+
 			`|> group(columns: ["hostname"]) `+
-			`|> mean() `+
-//			`|> aggregateWindow(every: 1h, fn: mean) `+
+			`|> aggregateWindow(every: 1h, fn: mean) `+
+			`|> keep(columns: ["_time", "_field", "_value", hostname"]) `+
 			`|> yield()`,
 			d.DatabaseName,
 			interval.StartString(), interval.EndString())

--- a/bulk_query_gen/influxdb/influx_devops_common.go
+++ b/bulk_query_gen/influxdb/influx_devops_common.go
@@ -89,11 +89,11 @@ func (d *InfluxDevops) maxCPUUsageHourByMinuteNHosts(qi bulkQuerygen.Query, nhos
 		query = fmt.Sprintf(`from(bucket:"%s") `+
 			`|> range(start:%s, stop:%s) `+
 			`|> filter(fn:(r) => r._measurement == "cpu" and r._field == "usage_user" and (%s)) `+
-			`|> keep(columns:["_start", "_stop", "_time", "_value", "hostname"]) `+
+			`|> keep(columns:["_start", "_stop", "_time", "_value"]) `+
 			`|> window(every: 1m) `+ // TODO replace with aggregateWindow when it is fixed
 			`|> max() `+
 			`|> window(every: inf) `+
-			`|> keep(columns:["_time", "_value", "hostname"]) `+
+			`|> keep(columns:["_time", "_value"]) `+
 			`|> yield()`,
 			d.DatabaseName,
 			interval.StartString(), interval.EndString(),

--- a/bulk_query_gen/influxdb/influx_devops_common.go
+++ b/bulk_query_gen/influxdb/influx_devops_common.go
@@ -86,7 +86,7 @@ func (d *InfluxDevops) maxCPUUsageHourByMinuteNHosts(qi bulkQuerygen.Query, nhos
 	if d.language == InfluxQL {
 		query = fmt.Sprintf("SELECT max(usage_user) from cpu where (%s) and time >= '%s' and time < '%s' group by time(1m)", combinedHostnameClause, interval.StartString(), interval.EndString())
 	} else { // Flux
-		query = fmt.Sprintf(`from(db:"%s") `+
+		query = fmt.Sprintf(`from(bucket:"%s") `+
 			`|> range(start:%s, stop:%s) `+
 			`|> filter(fn:(r) => r._measurement == "cpu" and r._field == "usage_user" and (%s)) `+
 			`|> keep(columns:["_start", "_stop", "_time", "_value"]) `+
@@ -113,7 +113,7 @@ func (d *InfluxDevops) MeanCPUUsageDayByHourAllHostsGroupbyHost(qi bulkQuerygen.
 	if d.language == InfluxQL {
 		query = fmt.Sprintf("SELECT mean(usage_user) from cpu where time >= '%s' and time < '%s' group by time(1h),hostname", interval.StartString(), interval.EndString())
 	} else {
-		query = fmt.Sprintf(`from(db:"%s") `+
+		query = fmt.Sprintf(`from(bucket:"%s") `+
 			`|> range(start:%s, stop:%s) `+
 			`|> filter(fn:(r) => r._measurement == "cpu" and r._field == "usage_user") `+
 			`|> keep(columns:["_start", "_stop", "hostname", "_value", "_time"]) `+

--- a/bulk_query_gen/influxdb/influx_devops_common.go
+++ b/bulk_query_gen/influxdb/influx_devops_common.go
@@ -90,8 +90,8 @@ func (d *InfluxDevops) maxCPUUsageHourByMinuteNHosts(qi bulkQuerygen.Query, nhos
 			`|> range(start:%s, stop:%s) `+
 			`|> filter(fn:(r) => r._measurement == "cpu" and r._field == "usage_user" and (%s)) `+
 			`|> group() `+
-			`|> aggregateWindow(every: 1m, fn: max, createEmpty: false) `+
-			`|> drop(columns:["_start", "_stop"])`,
+			`|> aggregateWindow(every: 1m, fn: max) `+
+			`|> yield()`,
 			d.DatabaseName,
 			interval.StartString(), interval.EndString(),
 			combinedHostnameClause)

--- a/bulk_query_gen/influxdb/influx_devops_common.go
+++ b/bulk_query_gen/influxdb/influx_devops_common.go
@@ -89,7 +89,7 @@ func (d *InfluxDevops) maxCPUUsageHourByMinuteNHosts(qi bulkQuerygen.Query, nhos
 		query = fmt.Sprintf(`from(bucket:"%s") `+
 			`|> range(start:%s, stop:%s) `+
 			`|> filter(fn:(r) => r._measurement == "cpu" and r._field == "usage_user" and (%s)) `+
-			`|> keep(columns:["_start", "_stop", "_time", "_value"]) `+
+			`|> keep(columns:["_start", "_stop", "_time", "_value", "hostname"]) `+
 			`|> window(every: 1m) `+ // TODO replace with aggregateWindow when it is fixed
 			`|> max() `+
 			`|> window(every: inf) `+

--- a/bulk_query_gen/influxdb/influx_devops_common.go
+++ b/bulk_query_gen/influxdb/influx_devops_common.go
@@ -89,10 +89,12 @@ func (d *InfluxDevops) maxCPUUsageHourByMinuteNHosts(qi bulkQuerygen.Query, nhos
 		query = fmt.Sprintf(`from(bucket:"%s") `+
 			`|> range(start:%s, stop:%s) `+
 			`|> filter(fn:(r) => r._measurement == "cpu" and r._field == "usage_user" and (%s)) `+
-			`|> keep(columns:["_start", "_stop", "_time", "_value"]) `+
+			//`|> keep(columns:["_start", "_stop", "_time", "_value"]) `+
+			`|> group() `+
 			`|> aggregateWindow(every: 1m, fn: max, createEmpty: false) `+
-			`|> keep(columns:["_time", "_value"]) `+
-			`|> yield()`,
+			//`|> keep(columns:["_time", "_value"]) `+
+			//`|> yield()`,
+			``,
 			d.DatabaseName,
 			interval.StartString(), interval.EndString(),
 			combinedHostnameClause)

--- a/bulk_query_gen/influxdb/influx_iot_common.go
+++ b/bulk_query_gen/influxdb/influx_iot_common.go
@@ -65,9 +65,7 @@ func (d *InfluxIot) averageTemperatureDayByHourNHomes(qi bulkQuerygen.Query, nHo
 		query = fmt.Sprintf(`from(bucket:"%s") `+
 			`|> range(start:%s, stop:%s) `+
 			`|> filter(fn:(r) => r._measurement == "air_condition_room" and r._field == "temperature" and (%s)) `+
-			`|> keep(columns:["_start", "_stop", "_time", "_value"]) `+
-			`|> window(every:1h) `+
-			`|> mean() `+
+			`|> aggregateWindow(every:1h, fn:mean) `+
 			`|> yield()`,
 			d.DatabaseName,
 			interval.StartString(), interval.EndString(),

--- a/bulk_query_gen/influxdb/influx_iot_common.go
+++ b/bulk_query_gen/influxdb/influx_iot_common.go
@@ -62,7 +62,7 @@ func (d *InfluxIot) averageTemperatureDayByHourNHomes(qi bulkQuerygen.Query, nHo
 	if d.language == InfluxQL {
 		query = fmt.Sprintf("SELECT mean(temperature) from air_condition_room where (%s) and time >= '%s' and time < '%s' group by time(1h)", combinedHomesClause, interval.StartString(), interval.EndString())
 	} else {
-		query = fmt.Sprintf(`from(db:"%s") `+
+		query = fmt.Sprintf(`from(bucket:"%s") `+
 			`|> range(start:%s, stop:%s) `+
 			`|> filter(fn:(r) => r._measurement == "air_condition_room" and r._field == "temperature" and (%s)) `+
 			`|> keep(columns:["_start", "_stop", "_time", "_value"]) `+

--- a/bulk_query_gen/query.go
+++ b/bulk_query_gen/query.go
@@ -23,6 +23,7 @@ var HTTPQueryPool sync.Pool = sync.Pool{
 			Method:           []byte{},
 			Path:             []byte{},
 			Body:             []byte{},
+			Language:         "",
 			StartTimestamp:   0,
 			EndTimestamp:     0,
 		}
@@ -37,6 +38,7 @@ type HTTPQuery struct {
 	Method           []byte
 	Path             []byte
 	Body             []byte
+	Language         string
 	StartTimestamp   int64
 	EndTimestamp     int64
 }
@@ -63,6 +65,7 @@ func (q *HTTPQuery) Release() {
 	q.Method = q.Method[:0]
 	q.Path = q.Path[:0]
 	q.Body = q.Body[:0]
+	q.Language = ""
 	q.StartTimestamp = 0
 	q.EndTimestamp = 0
 

--- a/cmd/bulk_load_influx/http_writer.go
+++ b/cmd/bulk_load_influx/http_writer.go
@@ -6,7 +6,6 @@ import (
 	"bytes"
 	"fmt"
 	"log"
-	"net/url"
 	"time"
 
 	"github.com/valyala/fasthttp"
@@ -57,26 +56,14 @@ type HTTPWriter struct {
 }
 
 // NewHTTPWriter returns a new HTTPWriter from the supplied HTTPWriterConfig.
-func NewHTTPWriter(c HTTPWriterConfig, consistency string) *HTTPWriter {
+func NewHTTPWriter(c HTTPWriterConfig, url string) *HTTPWriter {
 	return &HTTPWriter{
 		client: fasthttp.Client{
 			Name: "bulk_load_influx",
 			MaxIdleConnDuration: DefaultIdleConnectionTimeout,
 		},
 		c:   c,
-		url: []byte(c.Host + "/write?consistency=" + consistency + "&db=" + url.QueryEscape(c.Database)),
-	}
-}
-
-// NewHTTPWriter2 returns a new HTTPWriter from the supplied HTTPWriterConfig. (InfluxDB v2)
-func NewHTTPWriter2(c HTTPWriterConfig, consistency string) *HTTPWriter {
-	return &HTTPWriter{
-		client: fasthttp.Client{
-			Name: "bulk_load_influx",
-			MaxIdleConnDuration: DefaultIdleConnectionTimeout,
-		},
-		c:   c,
-		url: []byte(c.Host + "/api/v2/write?org=" + c.OrgId + "&bucket=" + c.BucketId + "&precision=ns&consistency=" + consistency),
+		url: []byte(url),
 	}
 }
 

--- a/cmd/bulk_load_influx/main.go
+++ b/cmd/bulk_load_influx/main.go
@@ -149,8 +149,13 @@ func (l *InfluxBulkLoad) Validate() {
 		l.backoffTimeOut = bulk_load.Runner.TimeLimit
 	}
 
-	// handle InfluxDB 2.x options
-	if l.organization != "" {
+	if l.organization != "" || l.token != "" {
+		if l.organization == "" {
+			log.Fatal("organization must be specified for InfluxDB v2")
+		}
+		if l.token == "" {
+			log.Fatal("token must be specified for InfluxDB v2")
+		}
 		organizations, err := l.listOrgs2(l.daemonUrls[0], l.organization)
 		if err != nil {
 			log.Fatalf("error listing organizations: %v", err)
@@ -158,14 +163,6 @@ func (l *InfluxBulkLoad) Validate() {
 		l.orgId, _ = organizations[l.organization]
 		if l.orgId == "" {
 			log.Fatalf("organization '%s' not found", l.organization)
-		}
-	}
-	if l.organization != "" || l.token != "" {
-		if l.organization == "" {
-			log.Fatal("organization must be specified for InfluxDB v2")
-		}
-		if l.token == "" {
-			log.Fatal("token must be specified for InfluxDB v2")
 		}
 		l.useApiV2 = true
 		log.Print("Using InfluxDB API version 2")

--- a/cmd/bulk_load_influx/main.go
+++ b/cmd/bulk_load_influx/main.go
@@ -566,12 +566,12 @@ func createDb2(daemonUrl, dbname string, replicationFactor int) (string, error) 
 		ID string `json:"id,omitempty"`
 		Name string `json:"name"`
 		Organization string `json:"organization"`
-		OrganizationID string `json:"organizationID"`
+		OrgID string `json:"orgID"`
 	}
 	bucket := bucketType{
 		Name: dbName,
 		Organization: dbOrganization,
-		OrganizationID: dbOrgId,
+		OrgID: dbOrgId,
 	}
 	bucketBytes, err := json.Marshal(bucket)
 	if err != nil {
@@ -681,7 +681,7 @@ func listDatabases2(daemonUrl string) (map[string]string, error) {
 		Buckets []struct {
 			Id string
 			Organization string
-			OrganizationID string
+			OrgID string
 			Name string
 		}
 	}

--- a/cmd/bulk_load_influx/main.go
+++ b/cmd/bulk_load_influx/main.go
@@ -151,7 +151,7 @@ func (l *InfluxBulkLoad) Validate() {
 			log.Fatalf("credentials-file must be set for InfluxDB v2")
 		}
 		useApiV2 = true
-		log.Print("Running against InfluxDB v2")
+		log.Print("Using InfluxDB API version 2")
 	}
 }
 

--- a/cmd/bulk_query_gen/main.go
+++ b/cmd/bulk_query_gen/main.go
@@ -109,30 +109,81 @@ var useCaseMatrix = map[string]map[string]map[string]bulkQueryGen.QueryGenerator
 	},
 	common.UseCaseDashboard: {
 		DashboardAll: {
-			"influx-http": influxdb.NewInfluxQLDashboardAll,
+			"influx-flux-http": influxdb.NewFluxDashboardAll,
+			"influx-http": 		influxdb.NewInfluxQLDashboardAll,
 		},
 		DashboardCpuNum: {
-			"influx-http": influxdb.NewInfluxQLDashboardCpuNum,
+			"influx-flux-http": influxdb.NewFluxDashboardCpuNum,
+			"influx-http": 		influxdb.NewInfluxQLDashboardCpuNum,
 		},
 		DashboardAvailability: {
-			"influx-http": influxdb.NewInfluxQLDashboardAvailability,
+			"influx-flux-http": influxdb.NewFluxDashboardAvailability,
+			"influx-http": 		influxdb.NewInfluxQLDashboardAvailability,
 		},
-		DashboardCpuUtilization:         {"influx-http": influxdb.NewInfluxQLDashboardCpuUtilization},
-		DashboardDiskAllocated:          {"influx-http": influxdb.NewInfluxQLDashboardDiskAllocated},
-		DashboardDiskUsage:              {"influx-http": influxdb.NewInfluxQLDashboardDiskUsage},
-		DashboardDiskUtilization:        {"influx-http": influxdb.NewInfluxQLDashboardDiskUtilization},
-		DashboardHttpRequestDuration:    {"influx-http": influxdb.NewInfluxQLDashboardHttpRequestDuration},
-		DashboardHttpRequests:           {"influx-http": influxdb.NewInfluxQLDashboardHttpRequests},
-		DashboardKapaCpu:                {"influx-http": influxdb.NewInfluxQLDashboardKapaCpu},
-		DashboardKapaLoad:               {"influx-http": influxdb.NewInfluxQLDashboardKapaLoad},
-		DashboardKapaRam:                {"influx-http": influxdb.NewInfluxQLDashboardKapaRam},
-		DashboardMemoryTotal:            {"influx-http": influxdb.NewInfluxQLDashboardMemoryTotal},
-		DashboardMemoryUtilization:      {"influx-http": influxdb.NewInfluxQLDashboardMemoryUtilization},
-		DashboardNginxRequests:          {"influx-http": influxdb.NewInfluxQLDashboardNginxRequests},
-		DashboardQueueBytes:             {"influx-http": influxdb.NewInfluxQLDashboardQueueBytes},
-		DashboardRedisMemoryUtilization: {"influx-http": influxdb.NewInfluxQLDashboardRedisMemoryUtilization},
-		DashboardSystemLoad:             {"influx-http": influxdb.NewInfluxQLDashboardSystemLoad},
-		DashboardThroughput:             {"influx-http": influxdb.NewInfluxQLDashboardThroughput},
+		DashboardCpuUtilization: {
+			"influx-flux-http": influxdb.NewFluxDashboardCpuUtilization,
+			"influx-http": 		influxdb.NewInfluxQLDashboardCpuUtilization,
+		},
+		DashboardDiskAllocated: {
+			"influx-flux-http": influxdb.NewFluxDashboardDiskAllocated,
+			"influx-http": 		influxdb.NewInfluxQLDashboardDiskAllocated,
+		},
+		DashboardDiskUsage: {
+			"influx-flux-http": influxdb.NewFluxDashboardDiskUsage,
+			"influx-http": 		influxdb.NewInfluxQLDashboardDiskUsage,
+		},
+		DashboardDiskUtilization: {
+			"influx-flux-http": influxdb.NewFluxDashboardDiskUtilization,
+			"influx-http": 		influxdb.NewInfluxQLDashboardDiskUtilization,
+		},
+		DashboardHttpRequestDuration: {
+			"influx-flux-http": influxdb.NewFluxDashboardHttpRequestDuration,
+			"influx-http": 		influxdb.NewInfluxQLDashboardHttpRequestDuration,
+		},
+		DashboardHttpRequests: {
+			"influx-flux-http": influxdb.NewFluxDashboardHttpRequests,
+			"influx-http": 		influxdb.NewInfluxQLDashboardHttpRequests,
+		},
+		DashboardKapaCpu: {
+			"influx-flux-http": influxdb.NewFluxDashboardKapaCpu,
+			"influx-http": 		influxdb.NewInfluxQLDashboardKapaCpu,
+		},
+		DashboardKapaLoad: {
+			"influx-flux-http": influxdb.NewFluxDashboardKapaLoad,
+			"influx-http": 		influxdb.NewInfluxQLDashboardKapaLoad,
+		},
+		DashboardKapaRam: {
+			"influx-flux-http": influxdb.NewFluxDashboardKapaRam,
+			"influx-http": 		influxdb.NewInfluxQLDashboardKapaRam,
+		},
+		DashboardMemoryTotal: {
+			"influx-flux-http": influxdb.NewFluxDashboardMemoryTotal,
+			"influx-http": 		influxdb.NewInfluxQLDashboardMemoryTotal,
+		},
+		DashboardMemoryUtilization: {
+			"influx-flux-http": influxdb.NewFluxDashboardMemoryUtilization,
+			"influx-http": 		influxdb.NewInfluxQLDashboardMemoryUtilization,
+		},
+		DashboardNginxRequests: {
+			"influx-flux-http": influxdb.NewFluxDashboardNginxRequests,
+			"influx-http": 		influxdb.NewInfluxQLDashboardNginxRequests,
+		},
+		DashboardQueueBytes: {
+			"influx-flux-http": influxdb.NewFluxDashboardQueueBytes,
+			"influx-http": 		influxdb.NewInfluxQLDashboardQueueBytes,
+		},
+		DashboardRedisMemoryUtilization: {
+			"influx-flux-http": influxdb.NewFluxDashboardRedisMemoryUtilization,
+			"influx-http": 		influxdb.NewInfluxQLDashboardRedisMemoryUtilization,
+		},
+		DashboardSystemLoad: {
+			"influx-flux-http": influxdb.NewFluxDashboardSystemLoad,
+			"influx-http": 		influxdb.NewInfluxQLDashboardSystemLoad,
+		},
+		DashboardThroughput: {
+			"influx-flux-http": influxdb.NewFluxDashboardThroughput,
+			"influx-http": 		influxdb.NewInfluxQLDashboardThroughput,
+		},
 	},
 }
 

--- a/cmd/bulk_query_gen/main.go
+++ b/cmd/bulk_query_gen/main.go
@@ -110,79 +110,79 @@ var useCaseMatrix = map[string]map[string]map[string]bulkQueryGen.QueryGenerator
 	common.UseCaseDashboard: {
 		DashboardAll: {
 			"influx-flux-http": influxdb.NewFluxDashboardAll,
-			"influx-http": 		influxdb.NewInfluxQLDashboardAll,
+			"influx-http": 	    influxdb.NewInfluxQLDashboardAll,
 		},
 		DashboardCpuNum: {
 			"influx-flux-http": influxdb.NewFluxDashboardCpuNum,
-			"influx-http": 		influxdb.NewInfluxQLDashboardCpuNum,
+			"influx-http": 	    influxdb.NewInfluxQLDashboardCpuNum,
 		},
 		DashboardAvailability: {
 			"influx-flux-http": influxdb.NewFluxDashboardAvailability,
-			"influx-http": 		influxdb.NewInfluxQLDashboardAvailability,
+			"influx-http": 	    influxdb.NewInfluxQLDashboardAvailability,
 		},
 		DashboardCpuUtilization: {
 			"influx-flux-http": influxdb.NewFluxDashboardCpuUtilization,
-			"influx-http": 		influxdb.NewInfluxQLDashboardCpuUtilization,
+			"influx-http": 	    influxdb.NewInfluxQLDashboardCpuUtilization,
 		},
 		DashboardDiskAllocated: {
 			"influx-flux-http": influxdb.NewFluxDashboardDiskAllocated,
-			"influx-http": 		influxdb.NewInfluxQLDashboardDiskAllocated,
+			"influx-http": 	    influxdb.NewInfluxQLDashboardDiskAllocated,
 		},
 		DashboardDiskUsage: {
 			"influx-flux-http": influxdb.NewFluxDashboardDiskUsage,
-			"influx-http": 		influxdb.NewInfluxQLDashboardDiskUsage,
+			"influx-http": 	    influxdb.NewInfluxQLDashboardDiskUsage,
 		},
 		DashboardDiskUtilization: {
 			"influx-flux-http": influxdb.NewFluxDashboardDiskUtilization,
-			"influx-http": 		influxdb.NewInfluxQLDashboardDiskUtilization,
+			"influx-http": 	    influxdb.NewInfluxQLDashboardDiskUtilization,
 		},
 		DashboardHttpRequestDuration: {
 			"influx-flux-http": influxdb.NewFluxDashboardHttpRequestDuration,
-			"influx-http": 		influxdb.NewInfluxQLDashboardHttpRequestDuration,
+			"influx-http": 	    influxdb.NewInfluxQLDashboardHttpRequestDuration,
 		},
 		DashboardHttpRequests: {
 			"influx-flux-http": influxdb.NewFluxDashboardHttpRequests,
-			"influx-http": 		influxdb.NewInfluxQLDashboardHttpRequests,
+			"influx-http": 	    influxdb.NewInfluxQLDashboardHttpRequests,
 		},
 		DashboardKapaCpu: {
 			"influx-flux-http": influxdb.NewFluxDashboardKapaCpu,
-			"influx-http": 		influxdb.NewInfluxQLDashboardKapaCpu,
+			"influx-http": 	    influxdb.NewInfluxQLDashboardKapaCpu,
 		},
 		DashboardKapaLoad: {
 			"influx-flux-http": influxdb.NewFluxDashboardKapaLoad,
-			"influx-http": 		influxdb.NewInfluxQLDashboardKapaLoad,
+			"influx-http": 	    influxdb.NewInfluxQLDashboardKapaLoad,
 		},
 		DashboardKapaRam: {
 			"influx-flux-http": influxdb.NewFluxDashboardKapaRam,
-			"influx-http": 		influxdb.NewInfluxQLDashboardKapaRam,
+			"influx-http": 	    influxdb.NewInfluxQLDashboardKapaRam,
 		},
 		DashboardMemoryTotal: {
 			"influx-flux-http": influxdb.NewFluxDashboardMemoryTotal,
-			"influx-http": 		influxdb.NewInfluxQLDashboardMemoryTotal,
+			"influx-http": 	    influxdb.NewInfluxQLDashboardMemoryTotal,
 		},
 		DashboardMemoryUtilization: {
 			"influx-flux-http": influxdb.NewFluxDashboardMemoryUtilization,
-			"influx-http": 		influxdb.NewInfluxQLDashboardMemoryUtilization,
+			"influx-http": 	    influxdb.NewInfluxQLDashboardMemoryUtilization,
 		},
 		DashboardNginxRequests: {
 			"influx-flux-http": influxdb.NewFluxDashboardNginxRequests,
-			"influx-http": 		influxdb.NewInfluxQLDashboardNginxRequests,
+			"influx-http": 	    influxdb.NewInfluxQLDashboardNginxRequests,
 		},
 		DashboardQueueBytes: {
 			"influx-flux-http": influxdb.NewFluxDashboardQueueBytes,
-			"influx-http": 		influxdb.NewInfluxQLDashboardQueueBytes,
+			"influx-http": 	    influxdb.NewInfluxQLDashboardQueueBytes,
 		},
 		DashboardRedisMemoryUtilization: {
 			"influx-flux-http": influxdb.NewFluxDashboardRedisMemoryUtilization,
-			"influx-http": 		influxdb.NewInfluxQLDashboardRedisMemoryUtilization,
+			"influx-http": 	    influxdb.NewInfluxQLDashboardRedisMemoryUtilization,
 		},
 		DashboardSystemLoad: {
 			"influx-flux-http": influxdb.NewFluxDashboardSystemLoad,
-			"influx-http": 		influxdb.NewInfluxQLDashboardSystemLoad,
+			"influx-http": 	    influxdb.NewInfluxQLDashboardSystemLoad,
 		},
 		DashboardThroughput: {
 			"influx-flux-http": influxdb.NewFluxDashboardThroughput,
-			"influx-http": 		influxdb.NewInfluxQLDashboardThroughput,
+			"influx-http": 	    influxdb.NewInfluxQLDashboardThroughput,
 		},
 	},
 }

--- a/cmd/bulk_query_gen/main.go
+++ b/cmd/bulk_query_gen/main.go
@@ -183,7 +183,7 @@ func init() {
 	}
 
 	flag.StringVar(&format, "format", "influx-http", "Format to emit. (Choices are in the use case matrix.)")
-	flag.StringVar(&documentFormat, "document-format", "", "Document format specification. (for mongo format 'simpleArrays'; leave empty for previous behaviour)")
+	flag.StringVar(&documentFormat, "document-format", "", "Document format specification. (for MongoDB format 'simpleArrays'; leave empty for previous behaviour)")
 	flag.StringVar(&useCase, "use-case", common.UseCaseChoices[0], "Use case to model. (Choices are in the use case matrix.)")
 	flag.StringVar(&queryType, "query-type", "", "Query type. (Choices are in the use case matrix.)")
 

--- a/cmd/query_benchmarker_influxdb/main.go
+++ b/cmd/query_benchmarker_influxdb/main.go
@@ -41,6 +41,7 @@ type InfluxQueryBenchmarker struct {
 	queryPool sync.Pool
 	queryChan chan []*http.Query
 
+	useApiV2  bool
 	authToken string // InfluxDB v2
 	bucketId  string // InfluxDB v2
 	orgId     string // InfluxDB v2
@@ -103,6 +104,7 @@ func (b *InfluxQueryBenchmarker) Validate() {
 		if b.orgId == "" {
 			log.Fatalf("organization '%s' not found", b.organization)
 		}
+		b.useApiV2 = true
 	}
 }
 
@@ -213,6 +215,9 @@ func (b *InfluxQueryBenchmarker) processQueries(w http.HTTPClient, workersGroup 
 	opts := &http.HTTPClientDoOptions{
 		Debug:                bulk_query.Benchmarker.Debug(),
 		PrettyPrintResponses: bulk_query.Benchmarker.PrettyPrintResponses(),
+	}
+	if b.useApiV2 {
+		opts.ContentType = "application/vnd.flux"
 	}
 	if b.orgId != "" {
 		opts.Path = []byte(fmt.Sprintf("/api/v2/query?orgID=%s", b.orgId))

--- a/cmd/query_benchmarker_influxdb/main.go
+++ b/cmd/query_benchmarker_influxdb/main.go
@@ -23,10 +23,10 @@ import (
 
 // Program option vars:
 type InfluxQueryBenchmarker struct {
-	csvDaemonUrls string
-	daemonUrls    []string
-	dbOrganization         string // InfluxDB v2
-	dbCredentialFile       string // InfluxDB v2
+	csvDaemonUrls    string
+	daemonUrls       []string
+	dbOrganization   string // InfluxDB v2
+	dbCredentialFile string // InfluxDB v2
 
 	dialTimeout        time.Duration
 	readTimeout        time.Duration

--- a/cmd/query_benchmarker_influxdb/main.go
+++ b/cmd/query_benchmarker_influxdb/main.go
@@ -220,7 +220,7 @@ func (b *InfluxQueryBenchmarker) processQueries(w http.HTTPClient, workersGroup 
 	if b.useApiV2 {
 		opts.ContentType = "application/vnd.flux"
 		opts.Accept = "application/csv"
-		opts.Path = []byte(fmt.Sprintf("/api/v2/query?orgID=%s", b.orgId))
+		//opts.Path = []byte(fmt.Sprintf("/api/v2/query?orgID=%s", b.orgId)) // to override generated path
 		opts.AuthToken = b.authToken
 	}
 	var queriesSeen int64
@@ -276,9 +276,9 @@ func (b *InfluxQueryBenchmarker) processSingleQuery(w http.HTTPClient, q *http.Q
 			doneCh <- 1
 		}
 	}()
-	if opts.Path != nil { // override Path when set (case: orgId is not null)
-		q.Path = opts.Path
-	}
+	//if opts.Path != nil { // override query path when set (InfluxDB 2.x)
+	//	q.Path = opts.Path
+	//}
 	lagMillis, err := w.Do(q, opts)
 	stat := statPool.Get().(*bulk_query.Stat)
 	stat.Init(q.HumanLabel, lagMillis)

--- a/cmd/query_benchmarker_influxdb/main.go
+++ b/cmd/query_benchmarker_influxdb/main.go
@@ -196,7 +196,8 @@ func (b *InfluxQueryBenchmarker) processQueries(w http.HTTPClient, workersGroup 
 		PrettyPrintResponses: bulk_query.Benchmarker.PrettyPrintResponses(),
 	}
 	if useApiV2 {
-		opts.OrgId = dbOrgId
+		opts.ContentType = "application/vnd.flux"
+		opts.Path = []byte(fmt.Sprintf("/api/v2/query?orgID=%s", dbOrgId))
 		opts.AuthToken = authToken
 	}
 	var queriesSeen int64
@@ -252,6 +253,9 @@ func (b *InfluxQueryBenchmarker) processSingleQuery(w http.HTTPClient, q *http.Q
 			doneCh <- 1
 		}
 	}()
+	if opts.Path != nil { // override
+		q.Path = opts.Path
+	}
 	lagMillis, err := w.Do(q, opts)
 	stat := statPool.Get().(*bulk_query.Stat)
 	stat.Init(q.HumanLabel, lagMillis)

--- a/cmd/query_benchmarker_influxdb/main.go
+++ b/cmd/query_benchmarker_influxdb/main.go
@@ -196,7 +196,6 @@ func (b *InfluxQueryBenchmarker) processQueries(w http.HTTPClient, workersGroup 
 		PrettyPrintResponses: bulk_query.Benchmarker.PrettyPrintResponses(),
 	}
 	if useApiV2 {
-		opts.ApiPath = "/api/v2"
 		opts.OrgId = dbOrgId
 		opts.AuthToken = authToken
 	}

--- a/cmd/query_benchmarker_influxdb/main.go
+++ b/cmd/query_benchmarker_influxdb/main.go
@@ -105,6 +105,7 @@ func (b *InfluxQueryBenchmarker) Validate() {
 			log.Fatalf("organization '%s' not found", b.organization)
 		}
 		b.useApiV2 = true
+		log.Print("Using InfluxDB API version 2")
 	}
 }
 
@@ -219,11 +220,7 @@ func (b *InfluxQueryBenchmarker) processQueries(w http.HTTPClient, workersGroup 
 	if b.useApiV2 {
 		opts.ContentType = "application/vnd.flux"
 		opts.Accept = "application/csv"
-	}
-	if b.orgId != "" {
 		opts.Path = []byte(fmt.Sprintf("/api/v2/query?orgID=%s", b.orgId))
-	}
-	if b.authToken != "" {
 		opts.AuthToken = b.authToken
 	}
 	var queriesSeen int64

--- a/cmd/query_benchmarker_influxdb/main.go
+++ b/cmd/query_benchmarker_influxdb/main.go
@@ -256,6 +256,15 @@ func (b *InfluxQueryBenchmarker) processSingleQuery(w http.HTTPClient, q *http.Q
 	if opts.Path != nil { // override
 		q.Path = opts.Path
 	}
+	if useApiV2 {
+		body, err := url.QueryUnescape(string(q.Body))
+		if err != nil {
+			log.Fatalf("queryUnescape error: %v", err)
+		}
+		if strings.HasPrefix(body, "query=") {
+			q.Body = []byte(body[len("query="):])
+		}
+	}
 	lagMillis, err := w.Do(q, opts)
 	stat := statPool.Get().(*bulk_query.Stat)
 	stat.Init(q.HumanLabel, lagMillis)

--- a/cmd/query_benchmarker_influxdb/main.go
+++ b/cmd/query_benchmarker_influxdb/main.go
@@ -218,6 +218,7 @@ func (b *InfluxQueryBenchmarker) processQueries(w http.HTTPClient, workersGroup 
 	}
 	if b.useApiV2 {
 		opts.ContentType = "application/vnd.flux"
+		opts.Accept = "application/csv"
 	}
 	if b.orgId != "" {
 		opts.Path = []byte(fmt.Sprintf("/api/v2/query?orgID=%s", b.orgId))

--- a/cmd/query_benchmarker_influxdb/main.go
+++ b/cmd/query_benchmarker_influxdb/main.go
@@ -220,8 +220,8 @@ func (b *InfluxQueryBenchmarker) processQueries(w http.HTTPClient, workersGroup 
 	if b.useApiV2 {
 		opts.ContentType = "application/vnd.flux"
 		opts.Accept = "application/csv"
-		//opts.Path = []byte(fmt.Sprintf("/api/v2/query?orgID=%s", b.orgId)) // to override generated path
 		opts.AuthToken = b.authToken
+		opts.Path = []byte(fmt.Sprintf("/api/v2/query?orgID=%s", b.orgId)) // query path is empty for 2.x in generated queries
 	}
 	var queriesSeen int64
 	for queries := range b.queryChan {
@@ -276,9 +276,9 @@ func (b *InfluxQueryBenchmarker) processSingleQuery(w http.HTTPClient, q *http.Q
 			doneCh <- 1
 		}
 	}()
-	//if opts.Path != nil { // override query path when set (InfluxDB 2.x)
-	//	q.Path = opts.Path
-	//}
+	if b.useApiV2 {
+		q.Path = opts.Path
+	}
 	lagMillis, err := w.Do(q, opts)
 	stat := statPool.Get().(*bulk_query.Stat)
 	stat.Init(q.HumanLabel, lagMillis)


### PR DESCRIPTION
This PR adds 2.x OSS support.

Note: Some Flux queries may use obsolete or inefficient code (`bulk_query_gen/influxdb`).