### PR TITLE
fix: the check for existing databases should ignore _internal database

### DIFF
--- a/cmd/bulk_load_influx/main.go
+++ b/cmd/bulk_load_influx/main.go
@@ -184,7 +184,8 @@ func (l *InfluxBulkLoad) CreateDb() {
 		log.Fatal(err)
 	}
 
-	if _, ok := existingDatabases["_internal"]; (ok == true && len(existingDatabases) > 1) || (ok == false && len(existingDatabases) > 0) {
+	delete(existingDatabases, "_internal")
+	if len(existingDatabases) > 0 {
 		var dbs []string
 		for key, _ := range existingDatabases {
 			dbs = append(dbs, key)


### PR DESCRIPTION
Currently the tool throws an exception and quits for 1.x enterprise clusters unless `--do-abort-on-exist=false` is passed, because the tool checks for _any_ existing databases. As far as I can tell, the `_internal` DB is created automatically, and should not count in the check for whether DBs already exist in the cluster