### PR TITLE
fix bug: create queryChan in prepare method

### DIFF
--- a/cmd/query_benchmarker_opentsdb/main.go
+++ b/cmd/query_benchmarker_opentsdb/main.go
@@ -67,6 +67,9 @@ func (b *OpenTsdbQueryBenchmarker) Prepare() {
 			}
 		},
 	}
+
+	// Make data and control channels:
+	b.queryChan = make(chan *Query)
 }
 
 func (b *OpenTsdbQueryBenchmarker) GetProcessor() bulk_query.Processor {


### PR DESCRIPTION
It was stuck when I executed the cmd. 

```
[root@docker-1 cmd]# ./bulk_query_gen/bulk_query_gen -format="opentsdb" -query-type "1-host-1-hr" -timestamp-start="2018-01-01T00:00:00Z" -timestamp-end="2018-01-02T00:00:00Z" -queries 1 | ./query_benchmarker_opentsdb/query_benchmarker_opentsdb -urls http://localhost:4242
using random seed 544118503
OpenTSDB max cpu, rand    1 hosts, rand 1h0m0s by 1m: 1 points
daemon URLs: [http://localhost:4242]
Trend statistics using 30 samples
Reading queries to buffer
Reading queries done
2021/05/11 15:40:10 Started querying with 1 workers
^C
```

The reason is queryChan was not created by make . `b.queryChan <- q` and  `q := range b.queryChan` will not work.

```
func (b *OpenTsdbQueryBenchmarker) RunScan(r io.Reader, closeChan chan int) {
	dec := gob.NewDecoder(r)

	n := int64(0)
loop:
	for {
		if bulk_query.Benchmarker.Limit() >= 0 && n >= bulk_query.Benchmarker.Limit() {
			break
		}

		q := b.queryPool.Get().(*Query)
		err := dec.Decode(q)
		if err == io.EOF {
			break
		}
		if err != nil {
			log.Fatal(err)
		}

		q.ID = n

		b.queryChan <- q

		n++
		select {
		case <-closeChan:
			fmt.Printf("Received finish request\n")
			break loop
		default:
		}
	}
	b.scanFinished = true
}

func (b *OpenTsdbQueryBenchmarker) processQueries(w *HTTPClient, workersGroup *sync.WaitGroup, statPool sync.Pool, statChan chan *bulk_query.Stat) {
	opts := &HTTPClientDoOptions{
		Debug:                bulk_query.Benchmarker.Debug(),
		PrettyPrintResponses: bulk_query.Benchmarker.PrettyPrintResponses(),
	}
	for q := range b.queryChan {
		lag, err := w.Do(q, opts)

		stat := statPool.Get().(*bulk_query.Stat)
		stat.Init(q.HumanLabel, lag)
		statChan <- stat

		b.queryPool.Put(q)
		if err != nil {
			log.Fatalf("Error during request: %s\n", err.Error())
		}
	}
	workersGroup.Done()
}

```