### PR TITLE
Enable option for json output for query benchmarker

### DIFF
--- a/bulk_query/http/fasthttp_client.go
+++ b/bulk_query/http/fasthttp_client.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"github.com/valyala/fasthttp"
+	"log"
 	"net"
 	"net/url"
 	"os"
@@ -29,8 +30,8 @@ func NewFastHTTPClient(host string, debug int, dialTimeout time.Duration, readTi
 				return fasthttp.DialTimeout(addr, dialTimeout)
 			},
 			MaxIdleConnDuration: idleConnectionTimeout,
-			ReadTimeout: readTimeout,
-			WriteTimeout: writeTimeout,
+			ReadTimeout:         readTimeout,
+			WriteTimeout:        writeTimeout,
 		},
 		HTTPClientCommon: HTTPClientCommon{
 			Host:       []byte(host),
@@ -78,7 +79,7 @@ func (w *FastHTTPClient) Do(q *Query, opts *HTTPClientDoOptions) (lag float64, e
 
 	if (err != nil || resp.StatusCode() != fasthttp.StatusOK) && opts.Debug == 5 {
 		values, _ := url.ParseQuery(string(uri))
-		fmt.Printf("debug: url: %s, path %s, parsed url - %s\n", string(uri), q.Path, values)
+		log.Printf("debug: url: %s, path %s, parsed url - %s\n", string(uri), q.Path, values)
 	}
 
 	// Check that the status code was 200 OK:

--- a/bulk_query/http/http_client.go
+++ b/bulk_query/http/http_client.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
+	"log"
 	"net"
 	"net/http"
 	"net/url"
@@ -27,10 +28,10 @@ func NewDefaultHTTPClient(host string, debug int, dialTimeout time.Duration, rea
 				Dial: (&net.Dialer{
 					Timeout: dialTimeout,
 				}).Dial,
-				MaxIdleConns: 0, // unlimited
+				MaxIdleConns:        0,   // unlimited
 				MaxIdleConnsPerHost: 100, // 0 would fallback to DefaultMaxIdleConnsPerHost ie. 2
-				MaxConnsPerHost: 0, // unlimited
-				IdleConnTimeout: idleConnectionTimeout,
+				MaxConnsPerHost:     0,   // unlimited
+				IdleConnTimeout:     idleConnectionTimeout,
 			},
 		},
 		HTTPClientCommon: HTTPClientCommon{
@@ -78,7 +79,7 @@ func (w *DefaultHTTPClient) Do(q *Query, opts *HTTPClientDoOptions) (lag float64
 
 	if (err != nil || resp.StatusCode != http.StatusOK) && opts.Debug == 5 {
 		values, _ := url.ParseQuery(string(uri))
-		fmt.Printf("debug: url: %s, path %s, parsed url - %s\n", string(uri), q.Path, values)
+		log.Printf("debug: url: %s, path %s, parsed url - %s\n", string(uri), q.Path, values)
 	}
 
 	// Check that the status code was 200 OK:

--- a/bulk_query/stats.go
+++ b/bulk_query/stats.go
@@ -2,6 +2,7 @@ package bulk_query
 
 import (
 	"fmt"
+	"log"
 	"math"
 	"sort"
 	"time"
@@ -9,15 +10,14 @@ import (
 
 // Stat represents one statistical measurement.
 type Stat struct {
-	Label []byte
-	Value float64
+	Label    []byte
+	Value    float64
 	IsActual bool
 }
 
-
 // Init safely initializes a stat while minimizing heap allocations.
 func (s *Stat) Init(label []byte, value float64) {
-	s.InitWithActual(label,value, true)
+	s.InitWithActual(label, value, true)
 }
 
 func (s *Stat) InitWithActual(label []byte, value float64, isActual bool) {
@@ -194,7 +194,7 @@ func (ls *TrendStat) Add(y float64) {
 }
 
 func NewTrendStat(size int, skipFirst bool) *TrendStat {
-	fmt.Printf("Trend statistics using %d samples\n", size)
+	log.Printf("Trend statistics using %d samples\n", size)
 	instance := TrendStat{
 		size:      size,
 		slope:     0,

--- a/cmd/query_benchmarker_influxdb/main.go
+++ b/cmd/query_benchmarker_influxdb/main.go
@@ -26,24 +26,24 @@ import (
 
 // Program option vars:
 type InfluxQueryBenchmarker struct {
-	csvDaemonUrls    string
-	daemonUrls       []string
-	organization     string // InfluxDB v2
-	token            string // InfluxDB v2
+	csvDaemonUrls string
+	daemonUrls    []string
+	organization  string // InfluxDB v2
+	token         string // InfluxDB v2
 
-	dialTimeout        time.Duration
-	readTimeout        time.Duration
-	writeTimeout       time.Duration
-	httpClientType     string
-	clientIndex        int
-	scanFinished       bool
+	dialTimeout    time.Duration
+	readTimeout    time.Duration
+	writeTimeout   time.Duration
+	httpClientType string
+	clientIndex    int
+	scanFinished   bool
 
 	queryPool sync.Pool
 	queryChan chan []*http.Query
 
-	useApiV2  bool
-	bucketId  string // InfluxDB v2
-	orgId     string // InfluxDB v2
+	useApiV2 bool
+	bucketId string // InfluxDB v2
+	orgId    string // InfluxDB v2
 }
 
 var querier = &InfluxQueryBenchmarker{}
@@ -77,10 +77,10 @@ func (b *InfluxQueryBenchmarker) Validate() {
 	if len(b.daemonUrls) == 0 {
 		log.Fatal("missing 'urls' flag")
 	}
-	fmt.Printf("daemon URLs: %v\n", b.daemonUrls)
+	log.Printf("daemon URLs: %v\n", b.daemonUrls)
 
 	if b.httpClientType == "fast" || b.httpClientType == "default" {
-		fmt.Printf("Using HTTP client: %v\n", b.httpClientType)
+		log.Printf("Using HTTP client: %v\n", b.httpClientType)
 		http.UseFastHttp = b.httpClientType == "fast"
 	} else {
 		log.Fatalf("Unsupported HTPP client type: %v", b.httpClientType)
@@ -320,7 +320,7 @@ func (l *InfluxQueryBenchmarker) listOrgs2(daemonUrl string, orgName string) (ma
 
 	type listingType struct {
 		Orgs []struct {
-			Id string
+			Id   string
 			Name string
 		}
 	}


### PR DESCRIPTION
These changes move all log messaging for influx query benchmarks to stderr, and add an option to print results as JSON to stdout.