### PR TITLE
HTTP queries for InfluxDB2 should never be GET

### DIFF
--- a/bulk_query_gen/influxdb/influx_common.go
+++ b/bulk_query_gen/influxdb/influx_common.go
@@ -25,13 +25,15 @@ type InfluxCommon struct {
 	bulkQuerygen.CommonParams
 	language     Language
 	DatabaseName string
+	version      int
 }
 
-func newInfluxCommon(lang Language, dbName string, interval bulkQuerygen.TimeInterval, scaleVar int) *InfluxCommon {
+func newInfluxCommon(lang Language, dbName string, interval bulkQuerygen.TimeInterval, scaleVar int, version int) *InfluxCommon {
 	return &InfluxCommon{
 		CommonParams: *bulkQuerygen.NewCommonParams(interval, scaleVar),
 		language:     lang,
-		DatabaseName: dbName}
+		DatabaseName: dbName,
+		version:      version}
 }
 
 // getHttpQuery gets the right kind of http request based on the language being used
@@ -40,7 +42,7 @@ func (d *InfluxCommon) getHttpQuery(humanLabel, intervalStart, query string, q *
 	q.HumanDescription = []byte(fmt.Sprintf("%s: %s", humanLabel, intervalStart))
 	q.Language = d.language.String()
 
-	if d.language == InfluxQL {
+	if d.language == InfluxQL && d.version == 1 {
 		getValues := url.Values{}
 		getValues.Set("db", d.DatabaseName)
 		getValues.Set("q", query)

--- a/bulk_query_gen/influxdb/influx_dashboard_common.go
+++ b/bulk_query_gen/influxdb/influx_dashboard_common.go
@@ -5,6 +5,7 @@ import (
 	"github.com/influxdata/influxdb-comparisons/bulk_data_gen/dashboard"
 	bulkQuerygen "github.com/influxdata/influxdb-comparisons/bulk_query_gen"
 	"math/rand"
+	"strconv"
 	"time"
 )
 
@@ -24,8 +25,12 @@ func newInfluxDashboard(lang Language, dbConfig bulkQuerygen.DatabaseConfig, int
 	if clustersCount == 0 {
 		clustersCount = 1
 	}
+	version, err := strconv.Atoi(dbConfig["influxVersion"])
+	if err != nil {
+		panic("invalid influx version")
+	}
 	return &InfluxDashboard{
-		InfluxCommon:  *newInfluxCommon(lang, dbConfig[bulkQuerygen.DatabaseName], interval, scaleVar),
+		InfluxCommon:  *newInfluxCommon(lang, dbConfig[bulkQuerygen.DatabaseName], interval, scaleVar, version),
 		ClustersCount: clustersCount,
 		TimeWindow:    bulkQuerygen.TimeWindow{interval.Start, duration},
 	}
@@ -57,7 +62,7 @@ func (d *InfluxDashboard) GetTimeConstraint(interval *bulkQuerygen.TimeInterval)
 	case "last":
 		s = fmt.Sprintf("time >= now() - %dh and time < now() - %dh", int64(2*interval.Duration().Hours()), int64(interval.Duration().Hours()))
 	case "recent":
-		s = fmt.Sprintf("time >= now() - %dh and time < now() - %dh", int64(interval.Duration().Hours() + 24), int64(24))
+		s = fmt.Sprintf("time >= now() - %dh and time < now() - %dh", int64(interval.Duration().Hours()+24), int64(24))
 	}
 	return s
 }

--- a/bulk_query_gen/influxdb/influx_devops_common.go
+++ b/bulk_query_gen/influxdb/influx_devops_common.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	bulkQuerygen "github.com/influxdata/influxdb-comparisons/bulk_query_gen"
 	"math/rand"
+	"strconv"
 	"strings"
 	"time"
 )
@@ -20,8 +21,12 @@ func newInfluxDevopsCommon(lang Language, dbConfig bulkQuerygen.DatabaseConfig, 
 		panic("need influx database name")
 	}
 
+	version, err := strconv.Atoi(dbConfig["influxVersion"])
+	if err != nil {
+		panic("invalid influx version")
+	}
 	return &InfluxDevops{
-		InfluxCommon: *newInfluxCommon(lang, dbConfig[bulkQuerygen.DatabaseName], interval, scaleVar),
+		InfluxCommon: *newInfluxCommon(lang, dbConfig[bulkQuerygen.DatabaseName], interval, scaleVar, version),
 	}
 }
 

--- a/bulk_query_gen/influxdb/influx_iot_common.go
+++ b/bulk_query_gen/influxdb/influx_iot_common.go
@@ -5,6 +5,7 @@ import (
 	bulkDataGenIot "github.com/influxdata/influxdb-comparisons/bulk_data_gen/iot"
 	bulkQuerygen "github.com/influxdata/influxdb-comparisons/bulk_query_gen"
 	"math/rand"
+	"strconv"
 	"strings"
 	"time"
 )
@@ -20,8 +21,12 @@ func NewInfluxIotCommon(lang Language, dbConfig bulkQuerygen.DatabaseConfig, que
 		panic("need influx database name")
 	}
 
+	version, err := strconv.Atoi(dbConfig["influxVersion"])
+	if err != nil {
+		panic("invalid influx version")
+	}
 	return &InfluxIot{
-		InfluxCommon: *newInfluxCommon(lang, dbConfig[bulkQuerygen.DatabaseName], queriesFullRange, scaleVar),
+		InfluxCommon: *newInfluxCommon(lang, dbConfig[bulkQuerygen.DatabaseName], queriesFullRange, scaleVar, version),
 	}
 }
 

--- a/bulk_query_gen/influxdb/influx_metaquery_common.go
+++ b/bulk_query_gen/influxdb/influx_metaquery_common.go
@@ -2,6 +2,7 @@ package influxdb
 
 import (
 	"fmt"
+	"strconv"
 	"time"
 
 	bulkQuerygen "github.com/influxdata/influxdb-comparisons/bulk_query_gen"
@@ -17,8 +18,12 @@ func NewInfluxMetaqueryCommon(lang Language, dbConfig bulkQuerygen.DatabaseConfi
 		panic("need influx database name")
 	}
 
+	version, err := strconv.Atoi(dbConfig["influxVersion"])
+	if err != nil {
+		panic("invalid influx version")
+	}
 	return &InfluxMetaquery{
-		InfluxCommon: *newInfluxCommon(lang, dbConfig[bulkQuerygen.DatabaseName], queriesFullRange, scaleVar),
+		InfluxCommon: *newInfluxCommon(lang, dbConfig[bulkQuerygen.DatabaseName], queriesFullRange, scaleVar, version),
 	}
 }
 


### PR DESCRIPTION
This should alleviate a bug in perf tests wherein HTTP queries in 2.x return 405 because they are submitting GETs instead of POSTs