### PR TITLE
feat: add window aggregate query-gen logic (and alias for data gen)

### DIFF
--- a/bulk_data_gen/common/simulation.go
+++ b/bulk_data_gen/common/simulation.go
@@ -3,16 +3,17 @@ package common
 import "time"
 
 const (
-	DefaultDateTimeStart = "2018-01-01T00:00:00Z"
-	DefaultDateTimeEnd   = "2018-01-02T00:00:00Z"
-	UseCaseDevOps        = "devops"
-	UseCaseIot           = "iot"
-	UseCaseDashboard     = "dashboard"
-	UseCaseMetaquery     = "metaquery"
+	DefaultDateTimeStart   = "2018-01-01T00:00:00Z"
+	DefaultDateTimeEnd     = "2018-01-02T00:00:00Z"
+	UseCaseDevOps          = "devops"
+	UseCaseIot             = "iot"
+	UseCaseDashboard       = "dashboard"
+	UseCaseMetaquery       = "metaquery"
+	UseCaseWindowAggregate = "window-agg"
 )
 
 // Use case choices:
-var UseCaseChoices = []string{UseCaseDevOps, UseCaseIot, UseCaseDashboard, UseCaseMetaquery}
+var UseCaseChoices = []string{UseCaseDevOps, UseCaseIot, UseCaseDashboard, UseCaseMetaquery, UseCaseWindowAggregate}
 
 // Simulator simulates a use case.
 type Simulator interface {

--- a/bulk_query_gen/influxdb/influx_windowagg_common.go
+++ b/bulk_query_gen/influxdb/influx_windowagg_common.go
@@ -1,0 +1,67 @@
+package influxdb
+
+import (
+	"fmt"
+	"time"
+
+	bulkQuerygen "github.com/influxdata/influxdb-comparisons/bulk_query_gen"
+)
+
+type Aggregate string
+
+const (
+	Count Aggregate = "count"
+	Sum   Aggregate = "sum"
+	Mean  Aggregate = "mean"
+	Min   Aggregate = "min"
+	Max   Aggregate = "max"
+	First Aggregate = "first"
+	Last  Aggregate = "last"
+)
+
+type InfluxWindowAggregateQuery struct {
+	InfluxCommon
+	aggregate Aggregate
+	interval  time.Duration
+}
+
+func NewInfluxWindowAggregateQuery(agg Aggregate, lang Language, dbConfig bulkQuerygen.DatabaseConfig, queriesFullRange bulkQuerygen.TimeInterval, queryInterval time.Duration, scaleVar int) bulkQuerygen.QueryGenerator {
+	if _, ok := dbConfig[bulkQuerygen.DatabaseName]; !ok {
+		panic("need influx database name")
+	}
+
+	return &InfluxWindowAggregateQuery{
+		InfluxCommon: *newInfluxCommon(lang, dbConfig[bulkQuerygen.DatabaseName], queriesFullRange, scaleVar),
+		aggregate:    agg,
+		interval:     queryInterval,
+	}
+}
+
+func (d *InfluxWindowAggregateQuery) Dispatch(i int) bulkQuerygen.Query {
+	q := bulkQuerygen.NewHTTPQuery()
+	d.WindowAggregateQuery(q)
+	return q
+}
+
+func (d *InfluxWindowAggregateQuery) WindowAggregateQuery(qi bulkQuerygen.Query) {
+	interval := d.AllInterval.RandWindow(time.Hour * 6)
+
+	var query string
+	if d.language == InfluxQL {
+		query = fmt.Sprintf("SELECT %s(temperature) FROM air_condition_room WHERE time > '%s' AND time < '%s' GROUP BY time(%s)",
+			d.aggregate, interval.StartString(), interval.EndString(), d.interval)
+	} else {
+		query = fmt.Sprintf(`from(bucket:"%s")
+            |> range(start:%s, stop:%s)
+            |> filter(fn:(r) => r._measurement == "air_condition_room" and r._field == "temperature")
+            |> aggregateWindow(every:%s, fn:%s)
+            |> yield()`,
+			d.DatabaseName,
+			interval.StartString(), interval.EndString(),
+			d.interval, d.aggregate)
+	}
+
+	humanLabel := fmt.Sprintf("InfluxDB (%s) %s temperature, rand %s by %s", d.language.String(), d.aggregate, interval.StartString(), d.interval)
+	q := qi.(*bulkQuerygen.HTTPQuery)
+	d.getHttpQuery(humanLabel, interval.StartString(), query, q)
+}

--- a/bulk_query_gen/influxdb/influx_windowagg_count.go
+++ b/bulk_query_gen/influxdb/influx_windowagg_count.go
@@ -1,0 +1,15 @@
+package influxdb
+
+import (
+	"time"
+
+	bulkQuerygen "github.com/influxdata/influxdb-comparisons/bulk_query_gen"
+)
+
+func NewInfluxQLWindowAggregateCount(dbConfig bulkQuerygen.DatabaseConfig, queriesFullRange bulkQuerygen.TimeInterval, queryInterval time.Duration, scaleVar int) bulkQuerygen.QueryGenerator {
+	return NewInfluxWindowAggregateQuery(Count, InfluxQL, dbConfig, queriesFullRange, queryInterval, scaleVar)
+}
+
+func NewFluxWindowAggregateCount(dbConfig bulkQuerygen.DatabaseConfig, queriesFullRange bulkQuerygen.TimeInterval, queryInterval time.Duration, scaleVar int) bulkQuerygen.QueryGenerator {
+	return NewInfluxWindowAggregateQuery(Count, Flux, dbConfig, queriesFullRange, queryInterval, scaleVar)
+}

--- a/bulk_query_gen/influxdb/influx_windowagg_first.go
+++ b/bulk_query_gen/influxdb/influx_windowagg_first.go
@@ -1,0 +1,15 @@
+package influxdb
+
+import (
+	"time"
+
+	bulkQuerygen "github.com/influxdata/influxdb-comparisons/bulk_query_gen"
+)
+
+func NewInfluxQLWindowAggregateFirst(dbConfig bulkQuerygen.DatabaseConfig, queriesFullRange bulkQuerygen.TimeInterval, queryInterval time.Duration, scaleVar int) bulkQuerygen.QueryGenerator {
+	return NewInfluxWindowAggregateQuery(First, InfluxQL, dbConfig, queriesFullRange, queryInterval, scaleVar)
+}
+
+func NewFluxWindowAggregateFirst(dbConfig bulkQuerygen.DatabaseConfig, queriesFullRange bulkQuerygen.TimeInterval, queryInterval time.Duration, scaleVar int) bulkQuerygen.QueryGenerator {
+	return NewInfluxWindowAggregateQuery(First, Flux, dbConfig, queriesFullRange, queryInterval, scaleVar)
+}

--- a/bulk_query_gen/influxdb/influx_windowagg_last.go
+++ b/bulk_query_gen/influxdb/influx_windowagg_last.go
@@ -1,0 +1,15 @@
+package influxdb
+
+import (
+	"time"
+
+	bulkQuerygen "github.com/influxdata/influxdb-comparisons/bulk_query_gen"
+)
+
+func NewInfluxQLWindowAggregateLast(dbConfig bulkQuerygen.DatabaseConfig, queriesFullRange bulkQuerygen.TimeInterval, queryInterval time.Duration, scaleVar int) bulkQuerygen.QueryGenerator {
+	return NewInfluxWindowAggregateQuery(Last, InfluxQL, dbConfig, queriesFullRange, queryInterval, scaleVar)
+}
+
+func NewFluxWindowAggregateLast(dbConfig bulkQuerygen.DatabaseConfig, queriesFullRange bulkQuerygen.TimeInterval, queryInterval time.Duration, scaleVar int) bulkQuerygen.QueryGenerator {
+	return NewInfluxWindowAggregateQuery(Last, Flux, dbConfig, queriesFullRange, queryInterval, scaleVar)
+}

--- a/bulk_query_gen/influxdb/influx_windowagg_max.go
+++ b/bulk_query_gen/influxdb/influx_windowagg_max.go
@@ -1,0 +1,15 @@
+package influxdb
+
+import (
+	"time"
+
+	bulkQuerygen "github.com/influxdata/influxdb-comparisons/bulk_query_gen"
+)
+
+func NewInfluxQLWindowAggregateMax(dbConfig bulkQuerygen.DatabaseConfig, queriesFullRange bulkQuerygen.TimeInterval, queryInterval time.Duration, scaleVar int) bulkQuerygen.QueryGenerator {
+	return NewInfluxWindowAggregateQuery(Max, InfluxQL, dbConfig, queriesFullRange, queryInterval, scaleVar)
+}
+
+func NewFluxWindowAggregateMax(dbConfig bulkQuerygen.DatabaseConfig, queriesFullRange bulkQuerygen.TimeInterval, queryInterval time.Duration, scaleVar int) bulkQuerygen.QueryGenerator {
+	return NewInfluxWindowAggregateQuery(Max, Flux, dbConfig, queriesFullRange, queryInterval, scaleVar)
+}

--- a/bulk_query_gen/influxdb/influx_windowagg_mean.go
+++ b/bulk_query_gen/influxdb/influx_windowagg_mean.go
@@ -1,0 +1,15 @@
+package influxdb
+
+import (
+	"time"
+
+	bulkQuerygen "github.com/influxdata/influxdb-comparisons/bulk_query_gen"
+)
+
+func NewInfluxQLWindowAggregateMean(dbConfig bulkQuerygen.DatabaseConfig, queriesFullRange bulkQuerygen.TimeInterval, queryInterval time.Duration, scaleVar int) bulkQuerygen.QueryGenerator {
+	return NewInfluxWindowAggregateQuery(Mean, InfluxQL, dbConfig, queriesFullRange, queryInterval, scaleVar)
+}
+
+func NewFluxWindowAggregateMean(dbConfig bulkQuerygen.DatabaseConfig, queriesFullRange bulkQuerygen.TimeInterval, queryInterval time.Duration, scaleVar int) bulkQuerygen.QueryGenerator {
+	return NewInfluxWindowAggregateQuery(Mean, Flux, dbConfig, queriesFullRange, queryInterval, scaleVar)
+}

--- a/bulk_query_gen/influxdb/influx_windowagg_min.go
+++ b/bulk_query_gen/influxdb/influx_windowagg_min.go
@@ -1,0 +1,15 @@
+package influxdb
+
+import (
+	"time"
+
+	bulkQuerygen "github.com/influxdata/influxdb-comparisons/bulk_query_gen"
+)
+
+func NewInfluxQLWindowAggregateMin(dbConfig bulkQuerygen.DatabaseConfig, queriesFullRange bulkQuerygen.TimeInterval, queryInterval time.Duration, scaleVar int) bulkQuerygen.QueryGenerator {
+	return NewInfluxWindowAggregateQuery(Min, InfluxQL, dbConfig, queriesFullRange, queryInterval, scaleVar)
+}
+
+func NewFluxWindowAggregateMin(dbConfig bulkQuerygen.DatabaseConfig, queriesFullRange bulkQuerygen.TimeInterval, queryInterval time.Duration, scaleVar int) bulkQuerygen.QueryGenerator {
+	return NewInfluxWindowAggregateQuery(Min, Flux, dbConfig, queriesFullRange, queryInterval, scaleVar)
+}

--- a/bulk_query_gen/influxdb/influx_windowagg_sum.go
+++ b/bulk_query_gen/influxdb/influx_windowagg_sum.go
@@ -1,0 +1,15 @@
+package influxdb
+
+import (
+	"time"
+
+	bulkQuerygen "github.com/influxdata/influxdb-comparisons/bulk_query_gen"
+)
+
+func NewInfluxQLWindowAggregateSum(dbConfig bulkQuerygen.DatabaseConfig, queriesFullRange bulkQuerygen.TimeInterval, queryInterval time.Duration, scaleVar int) bulkQuerygen.QueryGenerator {
+	return NewInfluxWindowAggregateQuery(Sum, InfluxQL, dbConfig, queriesFullRange, queryInterval, scaleVar)
+}
+
+func NewFluxWindowAggregateSum(dbConfig bulkQuerygen.DatabaseConfig, queriesFullRange bulkQuerygen.TimeInterval, queryInterval time.Duration, scaleVar int) bulkQuerygen.QueryGenerator {
+	return NewInfluxWindowAggregateQuery(Sum, Flux, dbConfig, queriesFullRange, queryInterval, scaleVar)
+}

--- a/cmd/bulk_data_gen/main.go
+++ b/cmd/bulk_data_gen/main.go
@@ -202,6 +202,8 @@ func main() {
 			HostOffset: scaleVarOffset,
 		}
 		sim = cfg.ToSimulator()
+	case common.UseCaseChoices[4]:
+		fallthrough
 	case common.UseCaseChoices[1]:
 		cfg := &iot.IotSimulatorConfig{
 			Start: timestampStart,

--- a/cmd/bulk_query_gen/main.go
+++ b/cmd/bulk_query_gen/main.go
@@ -198,6 +198,36 @@ var useCaseMatrix = map[string]map[string]map[string]bulkQueryGen.QueryGenerator
 			"influx-http":      influxdb.NewInfluxQLMetaqueryFieldKeys,
 		},
 	},
+	common.UseCaseWindowAggregate: {
+		string(influxdb.Count): {
+			"influx-flux-http": influxdb.NewFluxWindowAggregateCount,
+			"influx-http":      influxdb.NewInfluxQLWindowAggregateCount,
+		},
+		string(influxdb.Sum): {
+			"influx-flux-http": influxdb.NewFluxWindowAggregateSum,
+			"influx-http":      influxdb.NewInfluxQLWindowAggregateSum,
+		},
+		string(influxdb.Mean): {
+			"influx-flux-http": influxdb.NewFluxWindowAggregateMean,
+			"influx-http":      influxdb.NewInfluxQLWindowAggregateMean,
+		},
+		string(influxdb.Min): {
+			"influx-flux-http": influxdb.NewFluxWindowAggregateMin,
+			"influx-http":      influxdb.NewInfluxQLWindowAggregateMin,
+		},
+		string(influxdb.Max): {
+			"influx-flux-http": influxdb.NewFluxWindowAggregateMax,
+			"influx-http":      influxdb.NewInfluxQLWindowAggregateMax,
+		},
+		string(influxdb.First): {
+			"influx-flux-http": influxdb.NewFluxWindowAggregateFirst,
+			"influx-http":      influxdb.NewInfluxQLWindowAggregateFirst,
+		},
+		string(influxdb.Last): {
+			"influx-flux-http": influxdb.NewFluxWindowAggregateLast,
+			"influx-http":      influxdb.NewInfluxQLWindowAggregateLast,
+		},
+	},
 }
 
 // Program option vars:


### PR DESCRIPTION
The window-aggregate queries use the iot case's data. I've structured the generation so that every aggregate is its own query "type", so each one can be benchmarked and tracked independently. I'm not sure if that's helpful or more complicated than it needs to be; I know the Flux team tracked each aggregate separately, and there have been some single-aggregate bugs in the past.