### PR TITLE
feat: add query-gen cases for bare aggregates

### DIFF
--- a/bulk_data_gen/common/simulation.go
+++ b/bulk_data_gen/common/simulation.go
@@ -11,6 +11,7 @@ const (
 	UseCaseMetaquery       = "metaquery"
 	UseCaseWindowAggregate = "window-agg"
 	UseCaseGroupAggregate  = "group-agg"
+	UseCaseBareAggregate   = "bare-agg"
 )
 
 // Use case choices:
@@ -21,6 +22,7 @@ var UseCaseChoices = []string{
 	UseCaseMetaquery,
 	UseCaseWindowAggregate,
 	UseCaseGroupAggregate,
+	UseCaseBareAggregate,
 }
 
 // Simulator simulates a use case.

--- a/bulk_query_gen/influxdb/influx_bareagg_common.go
+++ b/bulk_query_gen/influxdb/influx_bareagg_common.go
@@ -1,0 +1,53 @@
+package influxdb
+
+import (
+	"fmt"
+	"time"
+
+	bulkQuerygen "github.com/influxdata/influxdb-comparisons/bulk_query_gen"
+)
+
+type InfluxBareAggregateQuery struct {
+	InfluxCommon
+	aggregate Aggregate
+}
+
+func NewInfluxBareAggregateQuery(agg Aggregate, lang Language, dbConfig bulkQuerygen.DatabaseConfig, queriesFullRange bulkQuerygen.TimeInterval, scaleVar int) bulkQuerygen.QueryGenerator {
+	if _, ok := dbConfig[bulkQuerygen.DatabaseName]; !ok {
+		panic("need influx database name")
+	}
+
+	return &InfluxBareAggregateQuery{
+		InfluxCommon: *newInfluxCommon(lang, dbConfig[bulkQuerygen.DatabaseName], queriesFullRange, scaleVar),
+		aggregate:    agg,
+	}
+}
+
+func (d *InfluxBareAggregateQuery) Dispatch(i int) bulkQuerygen.Query {
+	q := bulkQuerygen.NewHTTPQuery()
+	d.BareAggregateQuery(q)
+	return q
+}
+
+func (d *InfluxBareAggregateQuery) BareAggregateQuery(qi bulkQuerygen.Query) {
+	interval := d.AllInterval.RandWindow(time.Hour * 6)
+
+	var query string
+	if d.language == InfluxQL {
+		query = fmt.Sprintf("SELECT %s(temperature) FROM air_condition_room WHERE time > '%s' AND time < '%s'",
+			d.aggregate, interval.StartString(), interval.EndString())
+	} else {
+		query = fmt.Sprintf(`from(bucket:"%s")
+            |> range(start:%s, stop:%s)
+            |> filter(fn:(r) => r._measurement == "air_condition_room" and r._field == "temperature")
+            |> %s()
+            |> yield()`,
+			d.DatabaseName,
+			interval.StartString(), interval.EndString(),
+			d.aggregate)
+	}
+
+	humanLabel := fmt.Sprintf("InfluxDB (%s) %s temperature, rand %s", d.language.String(), d.aggregate, interval.StartString())
+	q := qi.(*bulkQuerygen.HTTPQuery)
+	d.getHttpQuery(humanLabel, interval.StartString(), query, q)
+}

--- a/bulk_query_gen/influxdb/influx_bareagg_count.go
+++ b/bulk_query_gen/influxdb/influx_bareagg_count.go
@@ -1,0 +1,15 @@
+package influxdb
+
+import (
+	"time"
+
+	bulkQuerygen "github.com/influxdata/influxdb-comparisons/bulk_query_gen"
+)
+
+func NewInfluxQLBareAggregateCount(dbConfig bulkQuerygen.DatabaseConfig, queriesFullRange bulkQuerygen.TimeInterval, _ time.Duration, scaleVar int) bulkQuerygen.QueryGenerator {
+	return NewInfluxBareAggregateQuery(Count, InfluxQL, dbConfig, queriesFullRange, scaleVar)
+}
+
+func NewFluxBareAggregateCount(dbConfig bulkQuerygen.DatabaseConfig, queriesFullRange bulkQuerygen.TimeInterval, _ time.Duration, scaleVar int) bulkQuerygen.QueryGenerator {
+	return NewInfluxBareAggregateQuery(Count, Flux, dbConfig, queriesFullRange, scaleVar)
+}

--- a/bulk_query_gen/influxdb/influx_bareagg_first.go
+++ b/bulk_query_gen/influxdb/influx_bareagg_first.go
@@ -1,0 +1,15 @@
+package influxdb
+
+import (
+	"time"
+
+	bulkQuerygen "github.com/influxdata/influxdb-comparisons/bulk_query_gen"
+)
+
+func NewInfluxQLBareAggregateFirst(dbConfig bulkQuerygen.DatabaseConfig, queriesFullRange bulkQuerygen.TimeInterval, _ time.Duration, scaleVar int) bulkQuerygen.QueryGenerator {
+	return NewInfluxBareAggregateQuery(First, InfluxQL, dbConfig, queriesFullRange, scaleVar)
+}
+
+func NewFluxBareAggregateFirst(dbConfig bulkQuerygen.DatabaseConfig, queriesFullRange bulkQuerygen.TimeInterval, _ time.Duration, scaleVar int) bulkQuerygen.QueryGenerator {
+	return NewInfluxBareAggregateQuery(First, Flux, dbConfig, queriesFullRange, scaleVar)
+}

--- a/bulk_query_gen/influxdb/influx_bareagg_last.go
+++ b/bulk_query_gen/influxdb/influx_bareagg_last.go
@@ -1,0 +1,15 @@
+package influxdb
+
+import (
+	"time"
+
+	bulkQuerygen "github.com/influxdata/influxdb-comparisons/bulk_query_gen"
+)
+
+func NewInfluxQLBareAggregateLast(dbConfig bulkQuerygen.DatabaseConfig, queriesFullRange bulkQuerygen.TimeInterval, _ time.Duration, scaleVar int) bulkQuerygen.QueryGenerator {
+	return NewInfluxBareAggregateQuery(Last, InfluxQL, dbConfig, queriesFullRange, scaleVar)
+}
+
+func NewFluxBareAggregateLast(dbConfig bulkQuerygen.DatabaseConfig, queriesFullRange bulkQuerygen.TimeInterval, _ time.Duration, scaleVar int) bulkQuerygen.QueryGenerator {
+	return NewInfluxBareAggregateQuery(Last, Flux, dbConfig, queriesFullRange, scaleVar)
+}

--- a/bulk_query_gen/influxdb/influx_bareagg_max.go
+++ b/bulk_query_gen/influxdb/influx_bareagg_max.go
@@ -1,0 +1,15 @@
+package influxdb
+
+import (
+	"time"
+
+	bulkQuerygen "github.com/influxdata/influxdb-comparisons/bulk_query_gen"
+)
+
+func NewInfluxQLBareAggregateMax(dbConfig bulkQuerygen.DatabaseConfig, queriesFullRange bulkQuerygen.TimeInterval, _ time.Duration, scaleVar int) bulkQuerygen.QueryGenerator {
+	return NewInfluxBareAggregateQuery(Max, InfluxQL, dbConfig, queriesFullRange, scaleVar)
+}
+
+func NewFluxBareAggregateMax(dbConfig bulkQuerygen.DatabaseConfig, queriesFullRange bulkQuerygen.TimeInterval, _ time.Duration, scaleVar int) bulkQuerygen.QueryGenerator {
+	return NewInfluxBareAggregateQuery(Max, Flux, dbConfig, queriesFullRange, scaleVar)
+}

--- a/bulk_query_gen/influxdb/influx_bareagg_mean.go
+++ b/bulk_query_gen/influxdb/influx_bareagg_mean.go
@@ -1,0 +1,15 @@
+package influxdb
+
+import (
+	"time"
+
+	bulkQuerygen "github.com/influxdata/influxdb-comparisons/bulk_query_gen"
+)
+
+func NewInfluxQLBareAggregateMean(dbConfig bulkQuerygen.DatabaseConfig, queriesFullRange bulkQuerygen.TimeInterval, _ time.Duration, scaleVar int) bulkQuerygen.QueryGenerator {
+	return NewInfluxBareAggregateQuery(Mean, InfluxQL, dbConfig, queriesFullRange, scaleVar)
+}
+
+func NewFluxBareAggregateMean(dbConfig bulkQuerygen.DatabaseConfig, queriesFullRange bulkQuerygen.TimeInterval, _ time.Duration, scaleVar int) bulkQuerygen.QueryGenerator {
+	return NewInfluxBareAggregateQuery(Mean, Flux, dbConfig, queriesFullRange, scaleVar)
+}

--- a/bulk_query_gen/influxdb/influx_bareagg_min.go
+++ b/bulk_query_gen/influxdb/influx_bareagg_min.go
@@ -1,0 +1,15 @@
+package influxdb
+
+import (
+	"time"
+
+	bulkQuerygen "github.com/influxdata/influxdb-comparisons/bulk_query_gen"
+)
+
+func NewInfluxQLBareAggregateMin(dbConfig bulkQuerygen.DatabaseConfig, queriesFullRange bulkQuerygen.TimeInterval, _ time.Duration, scaleVar int) bulkQuerygen.QueryGenerator {
+	return NewInfluxBareAggregateQuery(Min, InfluxQL, dbConfig, queriesFullRange, scaleVar)
+}
+
+func NewFluxBareAggregateMin(dbConfig bulkQuerygen.DatabaseConfig, queriesFullRange bulkQuerygen.TimeInterval, _ time.Duration, scaleVar int) bulkQuerygen.QueryGenerator {
+	return NewInfluxBareAggregateQuery(Min, Flux, dbConfig, queriesFullRange, scaleVar)
+}

--- a/bulk_query_gen/influxdb/influx_bareagg_sum.go
+++ b/bulk_query_gen/influxdb/influx_bareagg_sum.go
@@ -1,0 +1,15 @@
+package influxdb
+
+import (
+	"time"
+
+	bulkQuerygen "github.com/influxdata/influxdb-comparisons/bulk_query_gen"
+)
+
+func NewInfluxQLBareAggregateSum(dbConfig bulkQuerygen.DatabaseConfig, queriesFullRange bulkQuerygen.TimeInterval, _ time.Duration, scaleVar int) bulkQuerygen.QueryGenerator {
+	return NewInfluxBareAggregateQuery(Sum, InfluxQL, dbConfig, queriesFullRange, scaleVar)
+}
+
+func NewFluxBareAggregateSum(dbConfig bulkQuerygen.DatabaseConfig, queriesFullRange bulkQuerygen.TimeInterval, _ time.Duration, scaleVar int) bulkQuerygen.QueryGenerator {
+	return NewInfluxBareAggregateQuery(Sum, Flux, dbConfig, queriesFullRange, scaleVar)
+}

--- a/cmd/bulk_data_gen/main.go
+++ b/cmd/bulk_data_gen/main.go
@@ -206,6 +206,8 @@ func main() {
 		fallthrough
 	case common.UseCaseChoices[5]: // group-agg
 		fallthrough
+	case common.UseCaseChoices[6]: // bare-agg:
+		fallthrough
 	case common.UseCaseChoices[1]:
 		cfg := &iot.IotSimulatorConfig{
 			Start: timestampStart,

--- a/cmd/bulk_query_gen/main.go
+++ b/cmd/bulk_query_gen/main.go
@@ -258,6 +258,36 @@ var useCaseMatrix = map[string]map[string]map[string]bulkQueryGen.QueryGenerator
 			"influx-http":      influxdb.NewInfluxQLGroupAggregateMax,
 		},
 	},
+	common.UseCaseBareAggregate: {
+		string(influxdb.Count): {
+			"influx-flux-http": influxdb.NewFluxBareAggregateCount,
+			"influx-http":      influxdb.NewInfluxQLBareAggregateCount,
+		},
+		string(influxdb.Sum): {
+			"influx-flux-http": influxdb.NewFluxBareAggregateSum,
+			"influx-http":      influxdb.NewInfluxQLBareAggregateSum,
+		},
+		string(influxdb.Mean): {
+			"influx-flux-http": influxdb.NewFluxBareAggregateMean,
+			"influx-http":      influxdb.NewInfluxQLBareAggregateMean,
+		},
+		string(influxdb.First): {
+			"influx-flux-http": influxdb.NewFluxBareAggregateFirst,
+			"influx-http":      influxdb.NewInfluxQLBareAggregateFirst,
+		},
+		string(influxdb.Last): {
+			"influx-flux-http": influxdb.NewFluxBareAggregateLast,
+			"influx-http":      influxdb.NewInfluxQLBareAggregateLast,
+		},
+		string(influxdb.Min): {
+			"influx-flux-http": influxdb.NewFluxBareAggregateMin,
+			"influx-http":      influxdb.NewInfluxQLBareAggregateMin,
+		},
+		string(influxdb.Max): {
+			"influx-flux-http": influxdb.NewFluxBareAggregateMax,
+			"influx-http":      influxdb.NewInfluxQLBareAggregateMax,
+		},
+	},
 }
 
 // Program option vars:


### PR DESCRIPTION
Part of influxdata/influxdb#22015


# Summarization of results

## Setup

Data was reused from #183

Queries were generated using:
```
for format in influx-http influx-flux-http; do
  for agg in mean min max first last count sum; do
    bulk_query_gen -timestamp-end 2018-01-07T00:00:00Z -use-case bare-agg -format ${format} -query-type ${agg} -query-interval 3h
  done
done
```

I ran 1000 test queries per format/agg pair.

## Results

### count

| Query format | Min | Mean | Max |
| ---------: | --: | ---: | --: |
| influxql | 1075.375075 | 1840.4832337930022 | 5420.303289 |
| flux | 788.945928 | 977.169301243 | 3265.637433 |


### first

| Query format | Min | Mean | Max |
| ---------: | --: | ---: | --: |
| influxql | 759.275873 | 1347.7069262249995 | 2296.865368 |
| flux | 940.026132 | 1000.4270708260019 | 1121.242632 |


### last

| Query format | Min | Mean | Max |
| ---------: | --: | ---: | --: |
| influxql | 760.711906 | 1307.3349525719993 | 1518.371126 |
| flux | 953.409034 | 998.528391069001 | 1089.538072 |

### max

| Query format | Min | Mean | Max |
| ---------: | --: | ---: | --: |
| influxql | 929.012782 | 1865.1459989720024 | 3772.178092 |
| flux | 939.206382 | 1005.4248558010006 | 1070.570688 |


### mean

| Query format | Min | Mean | Max |
| ---------: | --: | ---: | --: |
| influxql | 945.807664 | 1824.1420364170012 | 2681.052062 |
| flux | 1066.604979 | 1144.579926059002 | 1221.251052 |


### min

| Query format | Min | Mean | Max |
| ---------: | --: | ---: | --: |
| influxql | 957.591881 | 1825.1550725820023 | 2704.928499 |
| flux | 949.556957 | 1027.9489226089995 | 1181.021262 |


### sum

| Query format | Min | Mean | Max |
| ---------: | --: | ---: | --: |
| influxql | 1151.982609 | 1816.5424587780046 | 2714.155983 |
| flux | 933.535967 | 995.9868039369995 | 1110.932114 |
