### PR TITLE
feat: allow for running influxql queries with compatbibility API

### DIFF
--- a/cmd/query_benchmarker_influxdb/main.go
+++ b/cmd/query_benchmarker_influxdb/main.go
@@ -108,7 +108,7 @@ func (b *InfluxQueryBenchmarker) Validate() {
 	}
 
 	if b.useCompatibilityApi && b.token == "" {
-		log.Fatal("organization must be specified when using compatibility API")
+		log.Fatal("token must be provided when using compatibility API")
 	}
 }
 


### PR DESCRIPTION
Adds a new CLI flag to the `query_benchmarker_influxdb` command `-use-compatibility` that will allow InfluxQL HTTP queries to be used with a 2.x influxd server via the compatibility `/query` API endpoint.

To use this endpoint, DBRPs need to be set up, and a `-token` needs to be provided with the command.