### PR TITLE
feat: add query for only filtered data for IoT use case

### DIFF
--- a/bulk_query_gen/influxdb/influx_iot_light_level.go
+++ b/bulk_query_gen/influxdb/influx_iot_light_level.go
@@ -1,0 +1,31 @@
+package influxdb
+
+import (
+	"time"
+
+	bulkQuerygen "github.com/influxdata/influxdb-comparisons/bulk_query_gen"
+)
+
+type InfluxIotLightLevel struct {
+	InfluxIot
+}
+
+func NewInfluxqlIotLightLevel(dbConfig bulkQuerygen.DatabaseConfig, queriesFullRange bulkQuerygen.TimeInterval, queryInterval time.Duration, scaleVar int) bulkQuerygen.QueryGenerator {
+	underlying := NewInfluxIotCommon(InfluxQL, dbConfig, queriesFullRange, queryInterval, scaleVar).(*InfluxIot)
+	return &InfluxIotLightLevel{
+		InfluxIot: *underlying,
+	}
+}
+
+func NewFluxIotLightLevel(dbConfig bulkQuerygen.DatabaseConfig, queriesFullRange bulkQuerygen.TimeInterval, queryInterval time.Duration, scaleVar int) bulkQuerygen.QueryGenerator {
+	underlying := NewInfluxIotCommon(Flux, dbConfig, queriesFullRange, queryInterval, scaleVar).(*InfluxIot)
+	return &InfluxIotLightLevel{
+		InfluxIot: *underlying,
+	}
+}
+
+func (d *InfluxIotLightLevel) Dispatch(i int) bulkQuerygen.Query {
+	q := bulkQuerygen.NewHTTPQuery() // from pool
+	d.LightLevelEightHours(q)
+	return q
+}

--- a/cmd/bulk_query_gen/main.go
+++ b/cmd/bulk_query_gen/main.go
@@ -32,6 +32,7 @@ const (
 	DevOpsGroupBy                   = "groupby"
 	IotOneHomeTwelveHours           = "1-home-12-hours"
 	IotAggregateKeep                = "aggregate-keep"
+	IotLightLevelEightHours         = "light-level-8-hr"
 	DashboardAll                    = "dashboard-all"
 	DashboardAvailability           = "availability"
 	DashboardCpuNum                 = "cpu-num"
@@ -113,6 +114,10 @@ var useCaseMatrix = map[string]map[string]map[string]bulkQueryGen.QueryGenerator
 		IotAggregateKeep: {
 			"influx-flux-http": influxdb.NewFluxIotAggregateKeep,
 			"influx-http":      influxdb.NewInfluxQLIotAggregateKeep,
+		},
+		IotLightLevelEightHours: {
+			"influx-flux-http": influxdb.NewFluxIotLightLevel,
+			"influx-http":      influxdb.NewInfluxqlIotLightLevel,
 		},
 	},
 	common.UseCaseDashboard: {


### PR DESCRIPTION
Part of https://github.com/influxdata/influxdb/issues/22149

Adds a query to the IoT use case that simply selects the `level` field from the `light_level_room` measurement between an 8-hour time range.

Testing locally with the IoT dataset used by the `influxdb` automated performance tests, the flux version is quite a bit faster, completing in about 7 seconds vs ~15 seconds for influxql.