### PR TITLE
chore: remove `GROUP BY *` from IoT light-level-8-hr

### DIFF
--- a/bulk_query_gen/influxdb/influx_iot_common.go
+++ b/bulk_query_gen/influxdb/influx_iot_common.go
@@ -108,7 +108,7 @@ func (d *InfluxIot) LightLevelEightHours(qi bulkQuerygen.Query) {
 
 	var query string
 	if d.language == InfluxQL {
-		query = fmt.Sprintf(`SELECT level FROM light_level_room WHERE time > '%s' AND time < '%s' GROUP BY *`, interval.StartString(), interval.EndString())
+		query = fmt.Sprintf(`SELECT level FROM light_level_room WHERE time > '%s' AND time < '%s'`, interval.StartString(), interval.EndString())
 	} else {
 		query = fmt.Sprintf(`from(bucket: "%s") `+
 			`|> range(start: %s, stop: %s) `+

--- a/bulk_query_gen/influxdb/influx_iot_common.go
+++ b/bulk_query_gen/influxdb/influx_iot_common.go
@@ -120,7 +120,7 @@ func (d *InfluxIot) LightLevelEightHours(qi bulkQuerygen.Query) {
 		)
 	}
 
-	humanLabel := fmt.Sprintf(`InfluxDB (%s) field keys`, d.language)
+	humanLabel := fmt.Sprintf(`InfluxDB (%s) 8 hrs Room Light Level (Raw Data)`, d.language)
 	q := qi.(*bulkQuerygen.HTTPQuery)
 	d.getHttpQuery(humanLabel, "n/a", query, q)
 }

--- a/bulk_query_gen/influxdb/influx_iot_light_level.go
+++ b/bulk_query_gen/influxdb/influx_iot_light_level.go
@@ -10,7 +10,7 @@ type InfluxIotLightLevel struct {
 	InfluxIot
 }
 
-func NewInfluxqlIotLightLevel(dbConfig bulkQuerygen.DatabaseConfig, queriesFullRange bulkQuerygen.TimeInterval, queryInterval time.Duration, scaleVar int) bulkQuerygen.QueryGenerator {
+func NewInfluxQLIotLightLevel(dbConfig bulkQuerygen.DatabaseConfig, queriesFullRange bulkQuerygen.TimeInterval, queryInterval time.Duration, scaleVar int) bulkQuerygen.QueryGenerator {
 	underlying := NewInfluxIotCommon(InfluxQL, dbConfig, queriesFullRange, queryInterval, scaleVar).(*InfluxIot)
 	return &InfluxIotLightLevel{
 		InfluxIot: *underlying,

--- a/cmd/bulk_query_gen/main.go
+++ b/cmd/bulk_query_gen/main.go
@@ -117,7 +117,7 @@ var useCaseMatrix = map[string]map[string]map[string]bulkQueryGen.QueryGenerator
 		},
 		IotLightLevelEightHours: {
 			"influx-flux-http": influxdb.NewFluxIotLightLevel,
-			"influx-http":      influxdb.NewInfluxqlIotLightLevel,
+			"influx-http":      influxdb.NewInfluxQLIotLightLevel,
 		},
 	},
 	common.UseCaseDashboard: {


### PR DESCRIPTION
As a follow-up to https://github.com/influxdata/influxdb-comparisons/pull/188, this removes the `GROUP BY *` statement from the InfluxQL query. This makes the InfluxQL query run a little bit faster, but still slower than the Flux query in my local tests.

Without the `GROUP BY *`, the list of results would look something like this:

```
{
    "results": [
        {
            "statement_id": 0,
            "series": [
                {
                    "name": "light_level_room",
                    "columns": [
                        "time",
                        "level"
                    ],
                    "values": [
                        [
                            "2018-01-01T03:12:00Z",
                            9999.817330076934
                        ],
                        [
                            "2018-01-01T03:12:00Z",
                            10015.688820248402
                        ],
                        [
                            "2018-01-01T03:12:00Z",
                            9983.836965520972
                        ]
                }
            ]
        }
    ]
}
```

With the `GROUP BY *`, the results are grouped like this:

```
{
    "results": [
        {
            "statement_id": 0,
            "series": [
                {
                    "name": "light_level_room",
                    "tags": {
                        "home_id": "0000000000000",
                        "room_id": "1",
                        "sensor_id": "0000000000007"
                    },
                    "columns": [
                        "time",
                        "level"
                    ],
                    "values": [
                        [
                            "2018-01-01T03:12:00Z",
                            9999.817330076934
                        ]
                    ]
                },
                {
                    "name": "light_level_room",
                    "tags": {
                        "home_id": "0000000000000",
                        "room_id": "2",
                        "sensor_id": "0000000000012"
                    },
                    "columns": [
                        "time",
                        "level"
                    ],
                    "values": [
                        [
                            "2018-01-01T03:12:00Z",
                            10005.001828465722
                        ]
                    ]
                }
            ]
        }
    ]
}
```

This second form is perhaps more directly comparable to the raw Flux output which includes separate tables for each result, but adds additional processing to the InfluxQL query compared to the Flux query. Since this query is being created in response to a concern that the Flux query is slower than the InfluxQL query, removing the extra processing step from the InfluxQL query and having the flux query still be actually faster provides a less obtuse comparison between the two.