### PR TITLE
feat: Flux Sorted Pivot perf test

### DIFF
--- a/bulk_query_gen/influxdb/influx_iot_common.go
+++ b/bulk_query_gen/influxdb/influx_iot_common.go
@@ -124,3 +124,24 @@ func (d *InfluxIot) LightLevelEightHours(qi bulkQuerygen.Query) {
 	q := qi.(*bulkQuerygen.HTTPQuery)
 	d.getHttpQuery(humanLabel, "n/a", query, q)
 }
+
+func (d *InfluxIot) IotSortedPivot(qi bulkQuerygen.Query) {
+	var query string
+	if d.language == InfluxQL {
+		query = fmt.Sprintf(`SELECT * WHERE time > '%s' AND time < '%s'`,
+			d.AllInterval.StartString(),
+			d.AllInterval.EndString())
+	} else {
+		query = fmt.Sprintf(`from(bucket: "%s" `+
+			`|> range(start: %s, stop: %s) `+
+			`|> filter(fn: (r) => r._measurememt == "air_quality_room") `+
+			`|> pivot(rowKey:["_time"], columnKey:["co2_level"])`, // todo do i need value key?
+			d.DatabaseName,
+			d.AllInterval.StartString(),
+			d.AllInterval.EndString())
+	}
+
+	humanLabel := fmt.Sprintf(`InfluxDB (%s) Sorted Pivot`, d.language)
+	q := qi.(*bulkQuerygen.HTTPQuery)
+	d.getHttpQuery(humanLabel, d.AllInterval.StartString(), query, q)
+}

--- a/bulk_query_gen/influxdb/influx_iot_common.go
+++ b/bulk_query_gen/influxdb/influx_iot_common.go
@@ -134,8 +134,8 @@ func (d *InfluxIot) IotSortedPivot(qi bulkQuerygen.Query) {
 	} else {
 		query = fmt.Sprintf(`from(bucket: "%s") `+
 			`|> range(start: %s, stop: %s) `+
-			`|> filter(fn: (r) => r._measurememt == "air_quality_room") `+
-			`|> pivot(rowKey:["_time"], columnKey:["_field"], valueKey:["_value"])`,
+			`|> filter(fn: (r) => r._measurement == "air_quality_room") `+
+			`|> pivot(rowKey:["_time"], columnKey:["_field"], valueKey:"_value")`,
 			d.DatabaseName,
 			d.AllInterval.StartString(),
 			d.AllInterval.EndString())

--- a/bulk_query_gen/influxdb/influx_iot_common.go
+++ b/bulk_query_gen/influxdb/influx_iot_common.go
@@ -128,7 +128,7 @@ func (d *InfluxIot) LightLevelEightHours(qi bulkQuerygen.Query) {
 func (d *InfluxIot) IotSortedPivot(qi bulkQuerygen.Query) {
 	var query string
 	if d.language == InfluxQL {
-		query = fmt.Sprintf(`SELECT * WHERE time > '%s' AND time < '%s'`,
+		query = fmt.Sprintf(`SELECT * FROM air_quality_room WHERE time > '%s' AND time < '%s'`,
 			d.AllInterval.StartString(),
 			d.AllInterval.EndString())
 	} else {

--- a/bulk_query_gen/influxdb/influx_iot_common.go
+++ b/bulk_query_gen/influxdb/influx_iot_common.go
@@ -132,10 +132,10 @@ func (d *InfluxIot) IotSortedPivot(qi bulkQuerygen.Query) {
 			d.AllInterval.StartString(),
 			d.AllInterval.EndString())
 	} else {
-		query = fmt.Sprintf(`from(bucket: "%s" `+
+		query = fmt.Sprintf(`from(bucket: "%s") `+
 			`|> range(start: %s, stop: %s) `+
 			`|> filter(fn: (r) => r._measurememt == "air_quality_room") `+
-			`|> pivot(rowKey:["_time"], columnKey:["co2_level"])`, // todo do i need value key?
+			`|> pivot(rowKey:["_time"], columnKey:["_field"], valueKey:["_value"])`,
 			d.DatabaseName,
 			d.AllInterval.StartString(),
 			d.AllInterval.EndString())

--- a/bulk_query_gen/influxdb/influx_iot_common.go
+++ b/bulk_query_gen/influxdb/influx_iot_common.go
@@ -125,23 +125,24 @@ func (d *InfluxIot) LightLevelEightHours(qi bulkQuerygen.Query) {
 	d.getHttpQuery(humanLabel, "n/a", query, q)
 }
 
-func (d *InfluxIot) IotSortedPivot(qi bulkQuerygen.Query) {
+func (d *InfluxIot) IotSortedPivot(qi bulkQuerygen.Query, timeInterval time.Duration) {
+	interval := d.AllInterval.RandWindow(timeInterval)
 	var query string
 	if d.language == InfluxQL {
 		query = fmt.Sprintf(`SELECT * FROM air_quality_room WHERE time > '%s' AND time < '%s'`,
-			d.AllInterval.StartString(),
-			d.AllInterval.EndString())
+			interval.StartString(),
+			interval.EndString())
 	} else {
 		query = fmt.Sprintf(`from(bucket: "%s") `+
 			`|> range(start: %s, stop: %s) `+
 			`|> filter(fn: (r) => r._measurement == "air_quality_room") `+
-			`|> pivot(rowKey:["_time"], columnKey:["_field"], valueKey:"_value")`,
+			`|> pivot(rowKey:["_time"], columnKey:["_field"], valueColumn:"_value")`,
 			d.DatabaseName,
-			d.AllInterval.StartString(),
-			d.AllInterval.EndString())
+			interval.StartString(),
+			interval.EndString())
 	}
 
 	humanLabel := fmt.Sprintf(`InfluxDB (%s) Sorted Pivot`, d.language)
 	q := qi.(*bulkQuerygen.HTTPQuery)
-	d.getHttpQuery(humanLabel, d.AllInterval.StartString(), query, q)
+	d.getHttpQuery(humanLabel, interval.StartString(), query, q)
 }

--- a/bulk_query_gen/influxdb/influx_iot_sorted_pivot.go
+++ b/bulk_query_gen/influxdb/influx_iot_sorted_pivot.go
@@ -9,24 +9,27 @@ import (
 // on Flux pivot function
 type InfluxIotSortedPivot struct {
 	InfluxIot
+	interval time.Duration
 }
 
 func NewInfluxQLIotSortedPivot(dbConfig bulkQuerygen.DatabaseConfig, queriesFullRange bulkQuerygen.TimeInterval, queryInterval time.Duration, scaleVar int) bulkQuerygen.QueryGenerator {
 	underlying := NewInfluxIotCommon(InfluxQL, dbConfig, queriesFullRange, queryInterval, scaleVar).(*InfluxIot)
 	return &InfluxIotSortedPivot{
 		InfluxIot: *underlying,
+		interval: queryInterval,
 	}
 }
 
 func NewFluxIotSortedPivot(dbConfig bulkQuerygen.DatabaseConfig, queriesFullRange bulkQuerygen.TimeInterval, queryInterval time.Duration, scaleVar int) bulkQuerygen.QueryGenerator {
 	underlying := NewInfluxIotCommon(Flux, dbConfig, queriesFullRange, queryInterval, scaleVar).(*InfluxIot)
-	return &InfluxIotAggregateKeep{
+	return &InfluxIotSortedPivot{
 		InfluxIot: *underlying,
+		interval: queryInterval,
 	}
 }
 
 func (d *InfluxIotSortedPivot) Dispatch(i int) bulkQuerygen.Query {
 	q := bulkQuerygen.NewHTTPQuery()
-	d.IotSortedPivot(q)
+	d.IotSortedPivot(q, d.interval)
 	return q
 }

--- a/bulk_query_gen/influxdb/influx_iot_sorted_pivot.go
+++ b/bulk_query_gen/influxdb/influx_iot_sorted_pivot.go
@@ -1,0 +1,32 @@
+package influxdb
+
+import (
+	bulkQuerygen "github.com/influxdata/influxdb-comparisons/bulk_query_gen"
+	"time"
+)
+
+// InfluxIotSortedPivot produces queries that will test performance
+// on Flux pivot function
+type InfluxIotSortedPivot struct {
+	InfluxIot
+}
+
+func NewInfluxQLIotSortedPivot(dbConfig bulkQuerygen.DatabaseConfig, queriesFullRange bulkQuerygen.TimeInterval, queryInterval time.Duration, scaleVar int) bulkQuerygen.QueryGenerator {
+	underlying := NewInfluxIotCommon(InfluxQL, dbConfig, queriesFullRange, queryInterval, scaleVar).(*InfluxIot)
+	return &InfluxIotSortedPivot{
+		InfluxIot: *underlying,
+	}
+}
+
+func NewFluxIotSortedPivot(dbConfig bulkQuerygen.DatabaseConfig, queriesFullRange bulkQuerygen.TimeInterval, queryInterval time.Duration, scaleVar int) bulkQuerygen.QueryGenerator {
+	underlying := NewInfluxIotCommon(Flux, dbConfig, queriesFullRange, queryInterval, scaleVar).(*InfluxIot)
+	return &InfluxIotAggregateKeep{
+		InfluxIot: *underlying,
+	}
+}
+
+func (d *InfluxIotSortedPivot) Dispatch(i int) bulkQuerygen.Query {
+	q := bulkQuerygen.NewHTTPQuery()
+	d.IotSortedPivot(q)
+	return q
+}

--- a/cmd/bulk_query_gen/main.go
+++ b/cmd/bulk_query_gen/main.go
@@ -33,6 +33,7 @@ const (
 	IotOneHomeTwelveHours           = "1-home-12-hours"
 	IotAggregateKeep                = "aggregate-keep"
 	IotLightLevelEightHours         = "light-level-8-hr"
+	IotSortedPivot                  = "sorted-pivot"
 	DashboardAll                    = "dashboard-all"
 	DashboardAvailability           = "availability"
 	DashboardCpuNum                 = "cpu-num"
@@ -118,6 +119,10 @@ var useCaseMatrix = map[string]map[string]map[string]bulkQueryGen.QueryGenerator
 		IotLightLevelEightHours: {
 			"influx-flux-http": influxdb.NewFluxIotLightLevel,
 			"influx-http":      influxdb.NewInfluxQLIotLightLevel,
+		},
+		IotSortedPivot: {
+			"influx-flux-http": influxdb.NewFluxIotSortedPivot,
+			"influx-http":      influxdb.NewInfluxQLIotSortedPivot,
 		},
 	},
 	common.UseCaseDashboard: {


### PR DESCRIPTION
Perf test for https://github.com/influxdata/influxdb/issues/22016.

The performance data I gathered:
||   max   |   mean  |
|----------------|:-------:|:-------:|
| InfluxQL (1.8) | 4.29ms | 0.26ms |
| Flux (2.x) | 19.39ms | 14.03ms |

This data is not completely fair, since the `pivot()` function does not exist in InfluxQL as stated [here](https://docs.influxdata.com/influxdb/v1.8/flux/flux-vs-influxql/#pivot), but since InfluxQL will pivot automatically, it should still be a valid test.