### PR TITLE
chore: fix panic caused by RandWindow in aggregate-keep use-case

### DIFF
--- a/bulk_query_gen/influxdb/influx_iot_aggregate_keep.go
+++ b/bulk_query_gen/influxdb/influx_iot_aggregate_keep.go
@@ -9,12 +9,14 @@ import (
 // on Flux statements aggregate and keep
 type InfluxIotAggregateKeep struct {
 	InfluxIot
+	interval time.Duration
 }
 
 func NewInfluxQLIotAggregateKeep(dbConfig bulkQuerygen.DatabaseConfig, queriesFullRange bulkQuerygen.TimeInterval, queryInterval time.Duration, scaleVar int) bulkQuerygen.QueryGenerator {
 	underlying := NewInfluxIotCommon(InfluxQL, dbConfig, queriesFullRange, queryInterval, scaleVar).(*InfluxIot)
 	return &InfluxIotAggregateKeep{
 		InfluxIot: *underlying,
+		interval: queryInterval,
 	}
 }
 
@@ -22,11 +24,12 @@ func NewFluxIotAggregateKeep(dbConfig bulkQuerygen.DatabaseConfig, queriesFullRa
 	underlying := NewInfluxIotCommon(Flux, dbConfig, queriesFullRange, queryInterval, scaleVar).(*InfluxIot)
 	return &InfluxIotAggregateKeep{
 		InfluxIot: *underlying,
+		interval: queryInterval,
 	}
 }
 
 func (d *InfluxIotAggregateKeep) Dispatch(i int) bulkQuerygen.Query {
 	q := bulkQuerygen.NewHTTPQuery() // from pool
-	d.IotAggregateKeep(q)
+	d.IotAggregateKeep(q, d.interval)
 	return q
 }

--- a/bulk_query_gen/influxdb/influx_iot_common.go
+++ b/bulk_query_gen/influxdb/influx_iot_common.go
@@ -122,5 +122,5 @@ func (d *InfluxIot) LightLevelEightHours(qi bulkQuerygen.Query) {
 
 	humanLabel := fmt.Sprintf(`InfluxDB (%s) 8 hrs Room Light Level (Raw Data)`, d.language)
 	q := qi.(*bulkQuerygen.HTTPQuery)
-	d.getHttpQuery(humanLabel, "n/a", query, q)
+	d.getHttpQuery(humanLabel, interval.StartString(), query, q)
 }

--- a/bulk_query_gen/influxdb/influx_iot_common.go
+++ b/bulk_query_gen/influxdb/influx_iot_common.go
@@ -78,8 +78,8 @@ func (d *InfluxIot) averageTemperatureDayByHourNHomes(qi bulkQuerygen.Query, nHo
 	d.getHttpQuery(humanLabel, interval.StartString(), query, q)
 }
 
-func (d *InfluxIot) IotAggregateKeep(qi bulkQuerygen.Query) {
-	interval := d.AllInterval.RandWindow(7 * 24 * time.Hour)
+func (d *InfluxIot) IotAggregateKeep(qi bulkQuerygen.Query, timeRange time.Duration) {
+	interval := d.AllInterval.RandWindow(timeRange)
 
 	var query string
 	if d.language == InfluxQL {
@@ -122,5 +122,5 @@ func (d *InfluxIot) LightLevelEightHours(qi bulkQuerygen.Query) {
 
 	humanLabel := fmt.Sprintf(`InfluxDB (%s) 8 hrs Room Light Level (Raw Data)`, d.language)
 	q := qi.(*bulkQuerygen.HTTPQuery)
-	d.getHttpQuery(humanLabel, interval.StartString(), query, q)
+	d.getHttpQuery(humanLabel, "n/a", query, q)
 }


### PR DESCRIPTION
Hopefully fixes an issue pointed out by @danxmoran where a panic was caused by "bad time bounds"