### PR TITLE
feat: queries for group window

### DIFF
--- a/bulk_data_gen/common/simulation.go
+++ b/bulk_data_gen/common/simulation.go
@@ -3,15 +3,16 @@ package common
 import "time"
 
 const (
-	DefaultDateTimeStart   = "2018-01-01T00:00:00Z"
-	DefaultDateTimeEnd     = "2018-01-02T00:00:00Z"
-	UseCaseDevOps          = "devops"
-	UseCaseIot             = "iot"
-	UseCaseDashboard       = "dashboard"
-	UseCaseMetaquery       = "metaquery"
-	UseCaseWindowAggregate = "window-agg"
-	UseCaseGroupAggregate  = "group-agg"
-	UseCaseBareAggregate   = "bare-agg"
+	DefaultDateTimeStart        = "2018-01-01T00:00:00Z"
+	DefaultDateTimeEnd          = "2018-01-02T00:00:00Z"
+	UseCaseDevOps               = "devops"
+	UseCaseIot                  = "iot"
+	UseCaseDashboard            = "dashboard"
+	UseCaseMetaquery            = "metaquery"
+	UseCaseWindowAggregate      = "window-agg"
+	UseCaseGroupAggregate       = "group-agg"
+	UseCaseBareAggregate        = "bare-agg"
+	UseCaseGroupWindowTranspose = "group-window-transpose"
 )
 
 // Use case choices:

--- a/bulk_query_gen/influxdb/influx_common.go
+++ b/bulk_query_gen/influxdb/influx_common.go
@@ -34,6 +34,13 @@ const (
 	Last  Aggregate = "last"
 )
 
+type Cardinality string
+
+const (
+	HighCardinality Cardinality = "high-card"
+	LowCardinality  Cardinality = "low-card"
+)
+
 type InfluxCommon struct {
 	bulkQuerygen.CommonParams
 	language     Language

--- a/bulk_query_gen/influxdb/influx_group_window_transpose_common.go
+++ b/bulk_query_gen/influxdb/influx_group_window_transpose_common.go
@@ -1,0 +1,86 @@
+package influxdb
+
+import (
+	"fmt"
+	"time"
+
+	bulkQuerygen "github.com/influxdata/influxdb-comparisons/bulk_query_gen"
+)
+
+type InfluxGroupWindowTransposeQuery struct {
+	InfluxCommon
+	aggregate   Aggregate
+	interval    time.Duration
+	cardinality Cardinality
+}
+
+func NewInfluxGroupWindowTransposeQuery(agg Aggregate, card Cardinality, lang Language, dbConfig bulkQuerygen.DatabaseConfig, queriesFullRange bulkQuerygen.TimeInterval, queryInterval time.Duration, scaleVar int) bulkQuerygen.QueryGenerator {
+	if _, ok := dbConfig[bulkQuerygen.DatabaseName]; !ok {
+		panic("need influx database name")
+	}
+
+	return &InfluxGroupWindowTransposeQuery{
+		InfluxCommon: *newInfluxCommon(lang, dbConfig[bulkQuerygen.DatabaseName], queriesFullRange, scaleVar),
+		aggregate:    agg,
+		interval:     queryInterval,
+		cardinality:  card,
+	}
+}
+
+func (d *InfluxGroupWindowTransposeQuery) Dispatch(i int) bulkQuerygen.Query {
+	q := bulkQuerygen.NewHTTPQuery()
+	if d.cardinality == LowCardinality {
+		d.GroupWindowTransposeQuery(q)
+	} else {
+		d.GroupWindowTransposeCardinalityQuery(q)
+	}
+	return q
+}
+
+func (d *InfluxGroupWindowTransposeQuery) GroupWindowTransposeQuery(qi bulkQuerygen.Query) {
+	interval := d.AllInterval.RandWindow(time.Hour * 6)
+
+	var query string
+	if d.language == InfluxQL {
+		query = fmt.Sprintf("SELECT %s(temperature) FROM air_condition_room WHERE time > '%s' AND time < '%s' GROUP BY time(%s),home_id",
+			d.aggregate, interval.StartString(), interval.EndString(), d.interval)
+	} else {
+		query = fmt.Sprintf(`from(bucket:"%s")
+            |> range(start:%s, stop:%s)
+            |> filter(fn:(r) => r._measurement == "air_condition_room" and r._field == "temperature")
+						|> group(columns:["home_id"])
+            |> aggregateWindow(every:%s, fn:%s)
+            |> yield()`,
+			d.DatabaseName,
+			interval.StartString(), interval.EndString(),
+			d.interval, d.aggregate)
+	}
+
+	humanLabel := fmt.Sprintf("InfluxDB (%s) %s temperature, grouped on home_id", d.language.String(), d.aggregate)
+	q := qi.(*bulkQuerygen.HTTPQuery)
+	d.getHttpQuery(humanLabel, interval.StartString(), query, q)
+}
+
+func (d *InfluxGroupWindowTransposeQuery) GroupWindowTransposeCardinalityQuery(qi bulkQuerygen.Query) {
+	interval := d.AllInterval.RandWindow(time.Hour * 12)
+
+	var query string
+	if d.language == InfluxQL {
+		query = fmt.Sprintf("SELECT %s(val) FROM example_measurement WHERE time > '%s' AND time < '%s' GROUP BY time(%s),X",
+			d.aggregate, interval.StartString(), interval.EndString(), d.interval)
+	} else {
+		query = fmt.Sprintf(`from(bucket:"%s")
+            |> range(start:%s, stop:%s)
+            |> filter(fn:(r) => r._measurement == "example_measurement" and r._field == "val")
+						|> group(columns:["X"])
+            |> aggregateWindow(every:%s, fn:%s)
+            |> yield()`,
+			d.DatabaseName,
+			interval.StartString(), interval.EndString(),
+			d.interval, d.aggregate)
+	}
+
+	humanLabel := fmt.Sprintf("InfluxDB (%s) %s val, grouped on X, high cardinality", d.language.String(), d.aggregate)
+	q := qi.(*bulkQuerygen.HTTPQuery)
+	d.getHttpQuery(humanLabel, interval.StartString(), query, q)
+}

--- a/bulk_query_gen/influxdb/influx_group_window_transpose_common.go
+++ b/bulk_query_gen/influxdb/influx_group_window_transpose_common.go
@@ -37,6 +37,8 @@ func (d *InfluxGroupWindowTransposeQuery) Dispatch(i int) bulkQuerygen.Query {
 	return q
 }
 
+// GroupWindowTransposeQuery generates a query based on the IoT data generator,
+// which represents a relatively low amount of cardinality.
 func (d *InfluxGroupWindowTransposeQuery) GroupWindowTransposeQuery(qi bulkQuerygen.Query) {
 	interval := d.AllInterval.RandWindow(time.Hour * 6)
 
@@ -46,11 +48,11 @@ func (d *InfluxGroupWindowTransposeQuery) GroupWindowTransposeQuery(qi bulkQuery
 			d.aggregate, interval.StartString(), interval.EndString(), d.interval)
 	} else {
 		query = fmt.Sprintf(`from(bucket:"%s")
-            |> range(start:%s, stop:%s)
-            |> filter(fn:(r) => r._measurement == "air_condition_room" and r._field == "temperature")
-						|> group(columns:["home_id"])
-            |> aggregateWindow(every:%s, fn:%s)
-            |> yield()`,
+				|> range(start:%s, stop:%s)
+				|> filter(fn:(r) => r._measurement == "air_condition_room" and r._field == "temperature")
+				|> group(columns:["home_id"])
+				|> aggregateWindow(every:%s, fn:%s)
+				|> yield()`,
 			d.DatabaseName,
 			interval.StartString(), interval.EndString(),
 			d.interval, d.aggregate)
@@ -61,6 +63,8 @@ func (d *InfluxGroupWindowTransposeQuery) GroupWindowTransposeQuery(qi bulkQuery
 	d.getHttpQuery(humanLabel, interval.StartString(), query, q)
 }
 
+// GroupWindowTransposeCardinalityQuery generates a query based on the Metaquery
+// data generator, which is much higher in cardinality.
 func (d *InfluxGroupWindowTransposeQuery) GroupWindowTransposeCardinalityQuery(qi bulkQuerygen.Query) {
 	interval := d.AllInterval.RandWindow(time.Hour * 12)
 
@@ -70,11 +74,11 @@ func (d *InfluxGroupWindowTransposeQuery) GroupWindowTransposeCardinalityQuery(q
 			d.aggregate, interval.StartString(), interval.EndString(), d.interval)
 	} else {
 		query = fmt.Sprintf(`from(bucket:"%s")
-            |> range(start:%s, stop:%s)
-            |> filter(fn:(r) => r._measurement == "example_measurement" and r._field == "val")
-						|> group(columns:["X"])
-            |> aggregateWindow(every:%s, fn:%s)
-            |> yield()`,
+				|> range(start:%s, stop:%s)
+				|> filter(fn:(r) => r._measurement == "example_measurement" and r._field == "val")
+				|> group(columns:["X"])
+				|> aggregateWindow(every:%s, fn:%s)
+				|> yield()`,
 			d.DatabaseName,
 			interval.StartString(), interval.EndString(),
 			d.interval, d.aggregate)

--- a/bulk_query_gen/influxdb/influx_group_window_transpose_count.go
+++ b/bulk_query_gen/influxdb/influx_group_window_transpose_count.go
@@ -6,22 +6,22 @@ import (
 	bulkQuerygen "github.com/influxdata/influxdb-comparisons/bulk_query_gen"
 )
 
-// InfluxQL query for "Group Window" on the stand cardinality IoT dataset
+// InfluxQL query for "Group Window" on the standard cardinality IoT dataset
 func NewInfluxQLGroupWindowTransposeCount(dbConfig bulkQuerygen.DatabaseConfig, queriesFullRange bulkQuerygen.TimeInterval, queryInterval time.Duration, scaleVar int) bulkQuerygen.QueryGenerator {
 	return NewInfluxGroupWindowTransposeQuery(Count, LowCardinality, InfluxQL, dbConfig, queriesFullRange, queryInterval, scaleVar)
 }
 
-// Flux Query query for "Group Window" on the stand cardinality IoT dataset
+// Flux Query query for "Group Window" on the standard cardinality IoT dataset
 func NewFluxGroupWindowTransposeCount(dbConfig bulkQuerygen.DatabaseConfig, queriesFullRange bulkQuerygen.TimeInterval, queryInterval time.Duration, scaleVar int) bulkQuerygen.QueryGenerator {
 	return NewInfluxGroupWindowTransposeQuery(Count, LowCardinality, Flux, dbConfig, queriesFullRange, queryInterval, scaleVar)
 }
 
-// InfluxQL query for "Group Window" on the high cardinality metaquery dataset
+// InfluxQL query for "Group Window" on the high cardinality Metaquery dataset
 func NewInfluxQLGroupWindowTransposeCountCardinality(dbConfig bulkQuerygen.DatabaseConfig, queriesFullRange bulkQuerygen.TimeInterval, queryInterval time.Duration, scaleVar int) bulkQuerygen.QueryGenerator {
 	return NewInfluxGroupWindowTransposeQuery(Count, HighCardinality, InfluxQL, dbConfig, queriesFullRange, queryInterval, scaleVar)
 }
 
-// Flux query for "Group Window" on the high cardinality metaquery dataset
+// Flux query for "Group Window" on the high cardinality Metaquery dataset
 func NewFluxGroupWindowTransposeCountCardinality(dbConfig bulkQuerygen.DatabaseConfig, queriesFullRange bulkQuerygen.TimeInterval, queryInterval time.Duration, scaleVar int) bulkQuerygen.QueryGenerator {
 	return NewInfluxGroupWindowTransposeQuery(Count, HighCardinality, Flux, dbConfig, queriesFullRange, queryInterval, scaleVar)
 }

--- a/bulk_query_gen/influxdb/influx_group_window_transpose_count.go
+++ b/bulk_query_gen/influxdb/influx_group_window_transpose_count.go
@@ -1,0 +1,27 @@
+package influxdb
+
+import (
+	"time"
+
+	bulkQuerygen "github.com/influxdata/influxdb-comparisons/bulk_query_gen"
+)
+
+// InfluxQL query for "Group Window" on the stand cardinality IoT dataset
+func NewInfluxQLGroupWindowTransposeCount(dbConfig bulkQuerygen.DatabaseConfig, queriesFullRange bulkQuerygen.TimeInterval, queryInterval time.Duration, scaleVar int) bulkQuerygen.QueryGenerator {
+	return NewInfluxGroupWindowTransposeQuery(Count, LowCardinality, InfluxQL, dbConfig, queriesFullRange, queryInterval, scaleVar)
+}
+
+// Flux Query query for "Group Window" on the stand cardinality IoT dataset
+func NewFluxGroupWindowTransposeCount(dbConfig bulkQuerygen.DatabaseConfig, queriesFullRange bulkQuerygen.TimeInterval, queryInterval time.Duration, scaleVar int) bulkQuerygen.QueryGenerator {
+	return NewInfluxGroupWindowTransposeQuery(Count, LowCardinality, Flux, dbConfig, queriesFullRange, queryInterval, scaleVar)
+}
+
+// InfluxQL query for "Group Window" on the high cardinality metaquery dataset
+func NewInfluxQLGroupWindowTransposeCountCardinality(dbConfig bulkQuerygen.DatabaseConfig, queriesFullRange bulkQuerygen.TimeInterval, queryInterval time.Duration, scaleVar int) bulkQuerygen.QueryGenerator {
+	return NewInfluxGroupWindowTransposeQuery(Count, HighCardinality, InfluxQL, dbConfig, queriesFullRange, queryInterval, scaleVar)
+}
+
+// Flux query for "Group Window" on the high cardinality metaquery dataset
+func NewFluxGroupWindowTransposeCountCardinality(dbConfig bulkQuerygen.DatabaseConfig, queriesFullRange bulkQuerygen.TimeInterval, queryInterval time.Duration, scaleVar int) bulkQuerygen.QueryGenerator {
+	return NewInfluxGroupWindowTransposeQuery(Count, HighCardinality, Flux, dbConfig, queriesFullRange, queryInterval, scaleVar)
+}

--- a/bulk_query_gen/influxdb/influx_group_window_transpose_first.go
+++ b/bulk_query_gen/influxdb/influx_group_window_transpose_first.go
@@ -1,0 +1,27 @@
+package influxdb
+
+import (
+	"time"
+
+	bulkQuerygen "github.com/influxdata/influxdb-comparisons/bulk_query_gen"
+)
+
+// InfluxQL query for "Group Window" on the standard cardinality IoT dataset
+func NewInfluxQLGroupWindowTransposeFirst(dbConfig bulkQuerygen.DatabaseConfig, queriesFullRange bulkQuerygen.TimeInterval, queryInterval time.Duration, scaleVar int) bulkQuerygen.QueryGenerator {
+	return NewInfluxGroupWindowTransposeQuery(First, LowCardinality, InfluxQL, dbConfig, queriesFullRange, queryInterval, scaleVar)
+}
+
+// Flux Query query for "Group Window" on the standard cardinality IoT dataset
+func NewFluxGroupWindowTransposeFirst(dbConfig bulkQuerygen.DatabaseConfig, queriesFullRange bulkQuerygen.TimeInterval, queryInterval time.Duration, scaleVar int) bulkQuerygen.QueryGenerator {
+	return NewInfluxGroupWindowTransposeQuery(First, LowCardinality, Flux, dbConfig, queriesFullRange, queryInterval, scaleVar)
+}
+
+// InfluxQL query for "Group Window" on the high cardinality Metaquery dataset
+func NewInfluxQLGroupWindowTransposeFirstCardinality(dbConfig bulkQuerygen.DatabaseConfig, queriesFullRange bulkQuerygen.TimeInterval, queryInterval time.Duration, scaleVar int) bulkQuerygen.QueryGenerator {
+	return NewInfluxGroupWindowTransposeQuery(First, HighCardinality, InfluxQL, dbConfig, queriesFullRange, queryInterval, scaleVar)
+}
+
+// Flux query for "Group Window" on the high cardinality Metaquery dataset
+func NewFluxGroupWindowTransposeFirstCardinality(dbConfig bulkQuerygen.DatabaseConfig, queriesFullRange bulkQuerygen.TimeInterval, queryInterval time.Duration, scaleVar int) bulkQuerygen.QueryGenerator {
+	return NewInfluxGroupWindowTransposeQuery(First, HighCardinality, Flux, dbConfig, queriesFullRange, queryInterval, scaleVar)
+}

--- a/bulk_query_gen/influxdb/influx_group_window_transpose_last.go
+++ b/bulk_query_gen/influxdb/influx_group_window_transpose_last.go
@@ -1,0 +1,27 @@
+package influxdb
+
+import (
+	"time"
+
+	bulkQuerygen "github.com/influxdata/influxdb-comparisons/bulk_query_gen"
+)
+
+// InfluxQL query for "Group Window" on the standard cardinality IoT dataset
+func NewInfluxQLGroupWindowTransposeLast(dbConfig bulkQuerygen.DatabaseConfig, queriesFullRange bulkQuerygen.TimeInterval, queryInterval time.Duration, scaleVar int) bulkQuerygen.QueryGenerator {
+	return NewInfluxGroupWindowTransposeQuery(Last, LowCardinality, InfluxQL, dbConfig, queriesFullRange, queryInterval, scaleVar)
+}
+
+// Flux Query query for "Group Window" on the standard cardinality IoT dataset
+func NewFluxGroupWindowTransposeLast(dbConfig bulkQuerygen.DatabaseConfig, queriesFullRange bulkQuerygen.TimeInterval, queryInterval time.Duration, scaleVar int) bulkQuerygen.QueryGenerator {
+	return NewInfluxGroupWindowTransposeQuery(Last, LowCardinality, Flux, dbConfig, queriesFullRange, queryInterval, scaleVar)
+}
+
+// InfluxQL query for "Group Window" on the high cardinality Metaquery dataset
+func NewInfluxQLGroupWindowTransposeLastCardinality(dbConfig bulkQuerygen.DatabaseConfig, queriesFullRange bulkQuerygen.TimeInterval, queryInterval time.Duration, scaleVar int) bulkQuerygen.QueryGenerator {
+	return NewInfluxGroupWindowTransposeQuery(Last, HighCardinality, InfluxQL, dbConfig, queriesFullRange, queryInterval, scaleVar)
+}
+
+// Flux query for "Group Window" on the high cardinality Metaquery dataset
+func NewFluxGroupWindowTransposeLastCardinality(dbConfig bulkQuerygen.DatabaseConfig, queriesFullRange bulkQuerygen.TimeInterval, queryInterval time.Duration, scaleVar int) bulkQuerygen.QueryGenerator {
+	return NewInfluxGroupWindowTransposeQuery(Last, HighCardinality, Flux, dbConfig, queriesFullRange, queryInterval, scaleVar)
+}

--- a/bulk_query_gen/influxdb/influx_group_window_transpose_max.go
+++ b/bulk_query_gen/influxdb/influx_group_window_transpose_max.go
@@ -6,22 +6,22 @@ import (
 	bulkQuerygen "github.com/influxdata/influxdb-comparisons/bulk_query_gen"
 )
 
-// InfluxQL query for "Group Window" on the stand cardinality IoT dataset
+// InfluxQL query for "Group Window" on the standard cardinality IoT dataset
 func NewInfluxQLGroupWindowTransposeMax(dbConfig bulkQuerygen.DatabaseConfig, queriesFullRange bulkQuerygen.TimeInterval, queryInterval time.Duration, scaleVar int) bulkQuerygen.QueryGenerator {
 	return NewInfluxGroupWindowTransposeQuery(Max, LowCardinality, InfluxQL, dbConfig, queriesFullRange, queryInterval, scaleVar)
 }
 
-// Flux Query query for "Group Window" on the stand cardinality IoT dataset
+// Flux Query query for "Group Window" on the standard cardinality IoT dataset
 func NewFluxGroupWindowTransposeMax(dbConfig bulkQuerygen.DatabaseConfig, queriesFullRange bulkQuerygen.TimeInterval, queryInterval time.Duration, scaleVar int) bulkQuerygen.QueryGenerator {
 	return NewInfluxGroupWindowTransposeQuery(Max, LowCardinality, Flux, dbConfig, queriesFullRange, queryInterval, scaleVar)
 }
 
-// InfluxQL query for "Group Window" on the high cardinality metaquery dataset
+// InfluxQL query for "Group Window" on the high cardinality Metaquery dataset
 func NewInfluxQLGroupWindowTransposeMaxCardinality(dbConfig bulkQuerygen.DatabaseConfig, queriesFullRange bulkQuerygen.TimeInterval, queryInterval time.Duration, scaleVar int) bulkQuerygen.QueryGenerator {
 	return NewInfluxGroupWindowTransposeQuery(Max, HighCardinality, InfluxQL, dbConfig, queriesFullRange, queryInterval, scaleVar)
 }
 
-// Flux query for "Group Window" on the high cardinality metaquery dataset
+// Flux query for "Group Window" on the high cardinality Metaquery dataset
 func NewFluxGroupWindowTransposeMaxCardinality(dbConfig bulkQuerygen.DatabaseConfig, queriesFullRange bulkQuerygen.TimeInterval, queryInterval time.Duration, scaleVar int) bulkQuerygen.QueryGenerator {
 	return NewInfluxGroupWindowTransposeQuery(Max, HighCardinality, Flux, dbConfig, queriesFullRange, queryInterval, scaleVar)
 }

--- a/bulk_query_gen/influxdb/influx_group_window_transpose_max.go
+++ b/bulk_query_gen/influxdb/influx_group_window_transpose_max.go
@@ -1,0 +1,27 @@
+package influxdb
+
+import (
+	"time"
+
+	bulkQuerygen "github.com/influxdata/influxdb-comparisons/bulk_query_gen"
+)
+
+// InfluxQL query for "Group Window" on the stand cardinality IoT dataset
+func NewInfluxQLGroupWindowTransposeMax(dbConfig bulkQuerygen.DatabaseConfig, queriesFullRange bulkQuerygen.TimeInterval, queryInterval time.Duration, scaleVar int) bulkQuerygen.QueryGenerator {
+	return NewInfluxGroupWindowTransposeQuery(Max, LowCardinality, InfluxQL, dbConfig, queriesFullRange, queryInterval, scaleVar)
+}
+
+// Flux Query query for "Group Window" on the stand cardinality IoT dataset
+func NewFluxGroupWindowTransposeMax(dbConfig bulkQuerygen.DatabaseConfig, queriesFullRange bulkQuerygen.TimeInterval, queryInterval time.Duration, scaleVar int) bulkQuerygen.QueryGenerator {
+	return NewInfluxGroupWindowTransposeQuery(Max, LowCardinality, Flux, dbConfig, queriesFullRange, queryInterval, scaleVar)
+}
+
+// InfluxQL query for "Group Window" on the high cardinality metaquery dataset
+func NewInfluxQLGroupWindowTransposeMaxCardinality(dbConfig bulkQuerygen.DatabaseConfig, queriesFullRange bulkQuerygen.TimeInterval, queryInterval time.Duration, scaleVar int) bulkQuerygen.QueryGenerator {
+	return NewInfluxGroupWindowTransposeQuery(Max, HighCardinality, InfluxQL, dbConfig, queriesFullRange, queryInterval, scaleVar)
+}
+
+// Flux query for "Group Window" on the high cardinality metaquery dataset
+func NewFluxGroupWindowTransposeMaxCardinality(dbConfig bulkQuerygen.DatabaseConfig, queriesFullRange bulkQuerygen.TimeInterval, queryInterval time.Duration, scaleVar int) bulkQuerygen.QueryGenerator {
+	return NewInfluxGroupWindowTransposeQuery(Max, HighCardinality, Flux, dbConfig, queriesFullRange, queryInterval, scaleVar)
+}

--- a/bulk_query_gen/influxdb/influx_group_window_transpose_mean.go
+++ b/bulk_query_gen/influxdb/influx_group_window_transpose_mean.go
@@ -1,0 +1,27 @@
+package influxdb
+
+import (
+	"time"
+
+	bulkQuerygen "github.com/influxdata/influxdb-comparisons/bulk_query_gen"
+)
+
+// InfluxQL query for "Group Window" on the standard cardinality IoT dataset
+func NewInfluxQLGroupWindowTransposeMean(dbConfig bulkQuerygen.DatabaseConfig, queriesFullRange bulkQuerygen.TimeInterval, queryInterval time.Duration, scaleVar int) bulkQuerygen.QueryGenerator {
+	return NewInfluxGroupWindowTransposeQuery(Mean, LowCardinality, InfluxQL, dbConfig, queriesFullRange, queryInterval, scaleVar)
+}
+
+// Flux Query query for "Group Window" on the standard cardinality IoT dataset
+func NewFluxGroupWindowTransposeMean(dbConfig bulkQuerygen.DatabaseConfig, queriesFullRange bulkQuerygen.TimeInterval, queryInterval time.Duration, scaleVar int) bulkQuerygen.QueryGenerator {
+	return NewInfluxGroupWindowTransposeQuery(Mean, LowCardinality, Flux, dbConfig, queriesFullRange, queryInterval, scaleVar)
+}
+
+// InfluxQL query for "Group Window" on the high cardinality Metaquery dataset
+func NewInfluxQLGroupWindowTransposeMeanCardinality(dbConfig bulkQuerygen.DatabaseConfig, queriesFullRange bulkQuerygen.TimeInterval, queryInterval time.Duration, scaleVar int) bulkQuerygen.QueryGenerator {
+	return NewInfluxGroupWindowTransposeQuery(Mean, HighCardinality, InfluxQL, dbConfig, queriesFullRange, queryInterval, scaleVar)
+}
+
+// Flux query for "Group Window" on the high cardinality Metaquery dataset
+func NewFluxGroupWindowTransposeMeanCardinality(dbConfig bulkQuerygen.DatabaseConfig, queriesFullRange bulkQuerygen.TimeInterval, queryInterval time.Duration, scaleVar int) bulkQuerygen.QueryGenerator {
+	return NewInfluxGroupWindowTransposeQuery(Mean, HighCardinality, Flux, dbConfig, queriesFullRange, queryInterval, scaleVar)
+}

--- a/bulk_query_gen/influxdb/influx_group_window_transpose_min.go
+++ b/bulk_query_gen/influxdb/influx_group_window_transpose_min.go
@@ -1,0 +1,27 @@
+package influxdb
+
+import (
+	"time"
+
+	bulkQuerygen "github.com/influxdata/influxdb-comparisons/bulk_query_gen"
+)
+
+// InfluxQL query for "Group Window" on the stand cardinality IoT dataset
+func NewInfluxQLGroupWindowTransposeMin(dbConfig bulkQuerygen.DatabaseConfig, queriesFullRange bulkQuerygen.TimeInterval, queryInterval time.Duration, scaleVar int) bulkQuerygen.QueryGenerator {
+	return NewInfluxGroupWindowTransposeQuery(Min, LowCardinality, InfluxQL, dbConfig, queriesFullRange, queryInterval, scaleVar)
+}
+
+// Flux Query query for "Group Window" on the stand cardinality IoT dataset
+func NewFluxGroupWindowTransposeMin(dbConfig bulkQuerygen.DatabaseConfig, queriesFullRange bulkQuerygen.TimeInterval, queryInterval time.Duration, scaleVar int) bulkQuerygen.QueryGenerator {
+	return NewInfluxGroupWindowTransposeQuery(Min, LowCardinality, Flux, dbConfig, queriesFullRange, queryInterval, scaleVar)
+}
+
+// InfluxQL query for "Group Window" on the high cardinality metaquery dataset
+func NewInfluxQLGroupWindowTransposeMinCardinality(dbConfig bulkQuerygen.DatabaseConfig, queriesFullRange bulkQuerygen.TimeInterval, queryInterval time.Duration, scaleVar int) bulkQuerygen.QueryGenerator {
+	return NewInfluxGroupWindowTransposeQuery(Min, HighCardinality, InfluxQL, dbConfig, queriesFullRange, queryInterval, scaleVar)
+}
+
+// Flux query for "Group Window" on the high cardinality metaquery dataset
+func NewFluxGroupWindowTransposeMinCardinality(dbConfig bulkQuerygen.DatabaseConfig, queriesFullRange bulkQuerygen.TimeInterval, queryInterval time.Duration, scaleVar int) bulkQuerygen.QueryGenerator {
+	return NewInfluxGroupWindowTransposeQuery(Min, HighCardinality, Flux, dbConfig, queriesFullRange, queryInterval, scaleVar)
+}

--- a/bulk_query_gen/influxdb/influx_group_window_transpose_min.go
+++ b/bulk_query_gen/influxdb/influx_group_window_transpose_min.go
@@ -6,22 +6,22 @@ import (
 	bulkQuerygen "github.com/influxdata/influxdb-comparisons/bulk_query_gen"
 )
 
-// InfluxQL query for "Group Window" on the stand cardinality IoT dataset
+// InfluxQL query for "Group Window" on the standard cardinality IoT dataset
 func NewInfluxQLGroupWindowTransposeMin(dbConfig bulkQuerygen.DatabaseConfig, queriesFullRange bulkQuerygen.TimeInterval, queryInterval time.Duration, scaleVar int) bulkQuerygen.QueryGenerator {
 	return NewInfluxGroupWindowTransposeQuery(Min, LowCardinality, InfluxQL, dbConfig, queriesFullRange, queryInterval, scaleVar)
 }
 
-// Flux Query query for "Group Window" on the stand cardinality IoT dataset
+// Flux Query query for "Group Window" on the standard cardinality IoT dataset
 func NewFluxGroupWindowTransposeMin(dbConfig bulkQuerygen.DatabaseConfig, queriesFullRange bulkQuerygen.TimeInterval, queryInterval time.Duration, scaleVar int) bulkQuerygen.QueryGenerator {
 	return NewInfluxGroupWindowTransposeQuery(Min, LowCardinality, Flux, dbConfig, queriesFullRange, queryInterval, scaleVar)
 }
 
-// InfluxQL query for "Group Window" on the high cardinality metaquery dataset
+// InfluxQL query for "Group Window" on the high cardinality Metaquery dataset
 func NewInfluxQLGroupWindowTransposeMinCardinality(dbConfig bulkQuerygen.DatabaseConfig, queriesFullRange bulkQuerygen.TimeInterval, queryInterval time.Duration, scaleVar int) bulkQuerygen.QueryGenerator {
 	return NewInfluxGroupWindowTransposeQuery(Min, HighCardinality, InfluxQL, dbConfig, queriesFullRange, queryInterval, scaleVar)
 }
 
-// Flux query for "Group Window" on the high cardinality metaquery dataset
+// Flux query for "Group Window" on the high cardinality Metaquery dataset
 func NewFluxGroupWindowTransposeMinCardinality(dbConfig bulkQuerygen.DatabaseConfig, queriesFullRange bulkQuerygen.TimeInterval, queryInterval time.Duration, scaleVar int) bulkQuerygen.QueryGenerator {
 	return NewInfluxGroupWindowTransposeQuery(Min, HighCardinality, Flux, dbConfig, queriesFullRange, queryInterval, scaleVar)
 }

--- a/bulk_query_gen/influxdb/influx_group_window_transpose_sum.go
+++ b/bulk_query_gen/influxdb/influx_group_window_transpose_sum.go
@@ -1,0 +1,27 @@
+package influxdb
+
+import (
+	"time"
+
+	bulkQuerygen "github.com/influxdata/influxdb-comparisons/bulk_query_gen"
+)
+
+// InfluxQL query for "Group Window" on the stand cardinality IoT dataset
+func NewInfluxQLGroupWindowTransposeSum(dbConfig bulkQuerygen.DatabaseConfig, queriesFullRange bulkQuerygen.TimeInterval, queryInterval time.Duration, scaleVar int) bulkQuerygen.QueryGenerator {
+	return NewInfluxGroupWindowTransposeQuery(Sum, LowCardinality, InfluxQL, dbConfig, queriesFullRange, queryInterval, scaleVar)
+}
+
+// Flux Query query for "Group Window" on the stand cardinality IoT dataset
+func NewFluxGroupWindowTransposeSum(dbConfig bulkQuerygen.DatabaseConfig, queriesFullRange bulkQuerygen.TimeInterval, queryInterval time.Duration, scaleVar int) bulkQuerygen.QueryGenerator {
+	return NewInfluxGroupWindowTransposeQuery(Sum, LowCardinality, Flux, dbConfig, queriesFullRange, queryInterval, scaleVar)
+}
+
+// InfluxQL query for "Group Window" on the high cardinality metaquery dataset
+func NewInfluxQLGroupWindowTransposeSumCardinality(dbConfig bulkQuerygen.DatabaseConfig, queriesFullRange bulkQuerygen.TimeInterval, queryInterval time.Duration, scaleVar int) bulkQuerygen.QueryGenerator {
+	return NewInfluxGroupWindowTransposeQuery(Sum, HighCardinality, InfluxQL, dbConfig, queriesFullRange, queryInterval, scaleVar)
+}
+
+// Flux query for "Group Window" on the high cardinality metaquery dataset
+func NewFluxGroupWindowTransposeSumCardinality(dbConfig bulkQuerygen.DatabaseConfig, queriesFullRange bulkQuerygen.TimeInterval, queryInterval time.Duration, scaleVar int) bulkQuerygen.QueryGenerator {
+	return NewInfluxGroupWindowTransposeQuery(Sum, HighCardinality, Flux, dbConfig, queriesFullRange, queryInterval, scaleVar)
+}

--- a/bulk_query_gen/influxdb/influx_group_window_transpose_sum.go
+++ b/bulk_query_gen/influxdb/influx_group_window_transpose_sum.go
@@ -6,22 +6,22 @@ import (
 	bulkQuerygen "github.com/influxdata/influxdb-comparisons/bulk_query_gen"
 )
 
-// InfluxQL query for "Group Window" on the stand cardinality IoT dataset
+// InfluxQL query for "Group Window" on the standard cardinality IoT dataset
 func NewInfluxQLGroupWindowTransposeSum(dbConfig bulkQuerygen.DatabaseConfig, queriesFullRange bulkQuerygen.TimeInterval, queryInterval time.Duration, scaleVar int) bulkQuerygen.QueryGenerator {
 	return NewInfluxGroupWindowTransposeQuery(Sum, LowCardinality, InfluxQL, dbConfig, queriesFullRange, queryInterval, scaleVar)
 }
 
-// Flux Query query for "Group Window" on the stand cardinality IoT dataset
+// Flux Query query for "Group Window" on the standard cardinality IoT dataset
 func NewFluxGroupWindowTransposeSum(dbConfig bulkQuerygen.DatabaseConfig, queriesFullRange bulkQuerygen.TimeInterval, queryInterval time.Duration, scaleVar int) bulkQuerygen.QueryGenerator {
 	return NewInfluxGroupWindowTransposeQuery(Sum, LowCardinality, Flux, dbConfig, queriesFullRange, queryInterval, scaleVar)
 }
 
-// InfluxQL query for "Group Window" on the high cardinality metaquery dataset
+// InfluxQL query for "Group Window" on the high cardinality Metaquery dataset
 func NewInfluxQLGroupWindowTransposeSumCardinality(dbConfig bulkQuerygen.DatabaseConfig, queriesFullRange bulkQuerygen.TimeInterval, queryInterval time.Duration, scaleVar int) bulkQuerygen.QueryGenerator {
 	return NewInfluxGroupWindowTransposeQuery(Sum, HighCardinality, InfluxQL, dbConfig, queriesFullRange, queryInterval, scaleVar)
 }
 
-// Flux query for "Group Window" on the high cardinality metaquery dataset
+// Flux query for "Group Window" on the high cardinality Metaquery dataset
 func NewFluxGroupWindowTransposeSumCardinality(dbConfig bulkQuerygen.DatabaseConfig, queriesFullRange bulkQuerygen.TimeInterval, queryInterval time.Duration, scaleVar int) bulkQuerygen.QueryGenerator {
 	return NewInfluxGroupWindowTransposeQuery(Sum, HighCardinality, Flux, dbConfig, queriesFullRange, queryInterval, scaleVar)
 }

--- a/cmd/bulk_query_gen/main.go
+++ b/cmd/bulk_query_gen/main.go
@@ -315,6 +315,30 @@ var useCaseMatrix = map[string]map[string]map[string]bulkQueryGen.QueryGenerator
 			"influx-flux-http": influxdb.NewFluxGroupWindowTransposeSumCardinality,
 			"influx-http":      influxdb.NewInfluxQLGroupWindowTransposeSumCardinality,
 		},
+		fmt.Sprintf("%s-%s", influxdb.Mean, influxdb.LowCardinality): {
+			"influx-flux-http": influxdb.NewFluxGroupWindowTransposeMean,
+			"influx-http":      influxdb.NewInfluxQLGroupWindowTransposeMean,
+		},
+		fmt.Sprintf("%s-%s", influxdb.Mean, influxdb.HighCardinality): {
+			"influx-flux-http": influxdb.NewFluxGroupWindowTransposeMeanCardinality,
+			"influx-http":      influxdb.NewInfluxQLGroupWindowTransposeMeanCardinality,
+		},
+		fmt.Sprintf("%s-%s", influxdb.First, influxdb.LowCardinality): {
+			"influx-flux-http": influxdb.NewFluxGroupWindowTransposeFirst,
+			"influx-http":      influxdb.NewInfluxQLGroupWindowTransposeFirst,
+		},
+		fmt.Sprintf("%s-%s", influxdb.First, influxdb.HighCardinality): {
+			"influx-flux-http": influxdb.NewFluxGroupWindowTransposeFirstCardinality,
+			"influx-http":      influxdb.NewInfluxQLGroupWindowTransposeFirstCardinality,
+		},
+		fmt.Sprintf("%s-%s", influxdb.Last, influxdb.LowCardinality): {
+			"influx-flux-http": influxdb.NewFluxGroupWindowTransposeLast,
+			"influx-http":      influxdb.NewInfluxQLGroupWindowTransposeLast,
+		},
+		fmt.Sprintf("%s-%s", influxdb.Last, influxdb.HighCardinality): {
+			"influx-flux-http": influxdb.NewFluxGroupWindowTransposeLastCardinality,
+			"influx-http":      influxdb.NewInfluxQLGroupWindowTransposeLastCardinality,
+		},
 		fmt.Sprintf("%s-%s", influxdb.Min, influxdb.LowCardinality): {
 			"influx-flux-http": influxdb.NewFluxGroupWindowTransposeMin,
 			"influx-http":      influxdb.NewInfluxQLGroupWindowTransposeMin,

--- a/cmd/bulk_query_gen/main.go
+++ b/cmd/bulk_query_gen/main.go
@@ -298,6 +298,40 @@ var useCaseMatrix = map[string]map[string]map[string]bulkQueryGen.QueryGenerator
 			"influx-http":      influxdb.NewInfluxQLBareAggregateMax,
 		},
 	},
+	common.UseCaseGroupWindowTranspose: {
+		fmt.Sprintf("%s-%s", influxdb.Count, influxdb.LowCardinality): {
+			"influx-flux-http": influxdb.NewFluxGroupWindowTransposeCount,
+			"influx-http":      influxdb.NewInfluxQLGroupWindowTransposeCount,
+		},
+		fmt.Sprintf("%s-%s", influxdb.Count, influxdb.HighCardinality): {
+			"influx-flux-http": influxdb.NewFluxGroupWindowTransposeCountCardinality,
+			"influx-http":      influxdb.NewInfluxQLGroupWindowTransposeCountCardinality,
+		},
+		fmt.Sprintf("%s-%s", influxdb.Sum, influxdb.LowCardinality): {
+			"influx-flux-http": influxdb.NewFluxGroupWindowTransposeSum,
+			"influx-http":      influxdb.NewInfluxQLGroupWindowTransposeSum,
+		},
+		fmt.Sprintf("%s-%s", influxdb.Sum, influxdb.HighCardinality): {
+			"influx-flux-http": influxdb.NewFluxGroupWindowTransposeSumCardinality,
+			"influx-http":      influxdb.NewInfluxQLGroupWindowTransposeSumCardinality,
+		},
+		fmt.Sprintf("%s-%s", influxdb.Min, influxdb.LowCardinality): {
+			"influx-flux-http": influxdb.NewFluxGroupWindowTransposeMin,
+			"influx-http":      influxdb.NewInfluxQLGroupWindowTransposeMin,
+		},
+		fmt.Sprintf("%s-%s", influxdb.Min, influxdb.HighCardinality): {
+			"influx-flux-http": influxdb.NewFluxGroupWindowTransposeMinCardinality,
+			"influx-http":      influxdb.NewInfluxQLGroupWindowTransposeMinCardinality,
+		},
+		fmt.Sprintf("%s-%s", influxdb.Max, influxdb.LowCardinality): {
+			"influx-flux-http": influxdb.NewFluxGroupWindowTransposeMax,
+			"influx-http":      influxdb.NewInfluxQLGroupWindowTransposeMax,
+		},
+		fmt.Sprintf("%s-%s", influxdb.Max, influxdb.HighCardinality): {
+			"influx-flux-http": influxdb.NewFluxGroupWindowTransposeMaxCardinality,
+			"influx-http":      influxdb.NewInfluxQLGroupWindowTransposeMaxCardinality,
+		},
+	},
 }
 
 // Program option vars:


### PR DESCRIPTION
Part of https://github.com/influxdata/influxdb/issues/22152

This adds query generators for queries involving a `group() |> aggregateWindow()` sequence of functions, or the equivalent InfluxQL query.

There is a (currently disabled via feature-flag) pushdown in OSS for these kinds of queries [here](https://github.com/influxdata/influxdb/blob/8e5a0705a3c14c69ab681268c4d7aecd98204434/query/stdlib/influxdata/influxdb/rules.go#L887-L897). It covers the aggregate functions of `count`, `sum`, `min`, and `max`, and the queries are aligned to the those. `mean`, `first`, and `last` are also included as query types, although these are not applicable to the pushdown.

Enabling that pushdown will cause some queries to be faster, but some to be slower. Queries covering data with high cardinality become slower with that pushdown enabled, so this PR allows for queries that run either against the standard IoT dataset we have been using in our benchmarks, and also ones that run against the high cardinality "metaquery" dataset.

Testing locally, here are some approximate results from running these queries against the combined IoT & metaquery dataset, with the pushdown feature flag toggled on vs off:

**feature flag on, flux:**
- normal cardinality: ~1000ms 
- high cardinality: ~740ms
*Note: This does not include the `mean`, `first`, and `last` queries, which are not covered by the pushdown. For these, the results are identical to with the feature flag off.*

**feature flag off, flux:**
- normal cardinality: ~8500ms
- high cardinality: ~470ms (note: actually faster with the pushdown turned off!)

**influxql (unchanged if feature flag is on or off):**
- normal cardinality: ~280ms
- high cardinality: ~277ms