### PR TITLE
feat: add iot query for multiple measurements with OR

### DIFF
--- a/bulk_query_gen/influxdb/influx_iot_battery_voltage.go
+++ b/bulk_query_gen/influxdb/influx_iot_battery_voltage.go
@@ -1,0 +1,34 @@
+package influxdb
+
+import (
+	"time"
+
+	bulkQuerygen "github.com/influxdata/influxdb-comparisons/bulk_query_gen"
+)
+
+type InfluxIotBatteryLevels struct {
+	InfluxIot
+	interval time.Duration
+}
+
+func NewInfluxQLIotBatteryLevels(dbConfig bulkQuerygen.DatabaseConfig, queriesFullRange bulkQuerygen.TimeInterval, queryInterval time.Duration, scaleVar int) bulkQuerygen.QueryGenerator {
+	underlying := NewInfluxIotCommon(InfluxQL, dbConfig, queriesFullRange, queryInterval, scaleVar).(*InfluxIot)
+	return &InfluxIotBatteryLevels{
+		InfluxIot: *underlying,
+		interval:  queryInterval,
+	}
+}
+
+func NewFluxIotBatteryLevels(dbConfig bulkQuerygen.DatabaseConfig, queriesFullRange bulkQuerygen.TimeInterval, queryInterval time.Duration, scaleVar int) bulkQuerygen.QueryGenerator {
+	underlying := NewInfluxIotCommon(Flux, dbConfig, queriesFullRange, queryInterval, scaleVar).(*InfluxIot)
+	return &InfluxIotBatteryLevels{
+		InfluxIot: *underlying,
+		interval:  queryInterval,
+	}
+}
+
+func (d *InfluxIotBatteryLevels) Dispatch(i int) bulkQuerygen.Query {
+	q := bulkQuerygen.NewHTTPQuery() // from pool
+	d.BatteryLevels(q, d.interval)
+	return q
+}

--- a/bulk_query_gen/influxdb/influx_iot_common.go
+++ b/bulk_query_gen/influxdb/influx_iot_common.go
@@ -125,6 +125,29 @@ func (d *InfluxIot) LightLevelEightHours(qi bulkQuerygen.Query) {
 	d.getHttpQuery(humanLabel, "n/a", query, q)
 }
 
+func (d *InfluxIot) BatteryLevels(qi bulkQuerygen.Query, queryInterval time.Duration) {
+	interval := d.AllInterval.RandWindow(queryInterval)
+
+	var query string
+	if d.language == InfluxQL {
+		query = fmt.Sprintf(`SELECT battery_voltage FROM air_condition_outdoor, air_condition_room, air_quality_room, camera_detection, door_state WHERE time > '%s' AND time < '%s'`, interval.StartString(), interval.EndString())
+	} else {
+		query = fmt.Sprintf(`from(bucket: "%s") `+
+			`|> range(start: %s, stop: %s) `+
+			`|> filter(fn: (r) => r["_measurement"] == "air_condition_outdoor" or r["_measurement"] == "air_condition_room" or r["_measurement"] == "air_quality_room" or r["_measurement"] == "camera_detection" or r["_measurement"] == "door_state") `+
+			`|> filter(fn: (r) => r["_field"] == "battery_voltage") `+
+			`|> yield()`,
+			d.DatabaseName,
+			interval.StartString(),
+			interval.EndString(),
+		)
+	}
+
+	humanLabel := fmt.Sprintf(`InfluxDB (%s) Battery Voltage`, d.language)
+	q := qi.(*bulkQuerygen.HTTPQuery)
+	d.getHttpQuery(humanLabel, "n/a", query, q)
+}
+
 func (d *InfluxIot) IotSortedPivot(qi bulkQuerygen.Query, timeInterval time.Duration) {
 	interval := d.AllInterval.RandWindow(timeInterval)
 	var query string

--- a/cmd/bulk_query_gen/main.go
+++ b/cmd/bulk_query_gen/main.go
@@ -33,6 +33,7 @@ const (
 	IotOneHomeTwelveHours           = "1-home-12-hours"
 	IotAggregateKeep                = "aggregate-keep"
 	IotLightLevelEightHours         = "light-level-8-hr"
+	IotBatteryLevels                = "battery-levels"
 	IotSortedPivot                  = "sorted-pivot"
 	DashboardAll                    = "dashboard-all"
 	DashboardAvailability           = "availability"
@@ -119,6 +120,10 @@ var useCaseMatrix = map[string]map[string]map[string]bulkQueryGen.QueryGenerator
 		IotLightLevelEightHours: {
 			"influx-flux-http": influxdb.NewFluxIotLightLevel,
 			"influx-http":      influxdb.NewInfluxQLIotLightLevel,
+		},
+		IotBatteryLevels: {
+			"influx-flux-http": influxdb.NewFluxIotBatteryLevels,
+			"influx-http":      influxdb.NewInfluxQLIotBatteryLevels,
 		},
 		IotSortedPivot: {
 			"influx-flux-http": influxdb.NewFluxIotSortedPivot,


### PR DESCRIPTION
Part of https://github.com/influxdata/influxdb/issues/22156

This PR adds a query to the IoT queries that queries over multiple measurements with an OR condition in the case of the Flux query.

Flux queries are usually slower than InfluxQL doing this kind of query, depending on the time range covered by the query. If the time range is relatively small compared to the total time range in which data exists, the flux queries will be significantly slower, presumably due to [this code](https://github.com/influxdata/influxdb/blob/master/v1/services/storage/series_cursor.go#L97) requiring a full block scan to determine the results for flux. As the time range of the query approaches the full range in which data exists, the gap closes and flux actually becomes faster than InfluxQL once the query time range is near the time range for the data. At this point I assume the full block scan is not much different than what is needed to get the entire dataset.

Because of this, the query interval for this query is configurable with the `-query-interval` flag. For an IoT dataset with the `-scale-var` set to 1000 with data over a 12 hour timeframe, a `-query-interval` of 5 minutes results in Flux queries taking about ~800ms to completed, compared to InfluxQL queries taking about ~350ms per my local testing.