### PR TITLE
chore: fix filter not being formatted correctly in `aggregate-keep`

### DIFF
--- a/bulk_query_gen/influxdb/influx_iot_common.go
+++ b/bulk_query_gen/influxdb/influx_iot_common.go
@@ -90,7 +90,7 @@ func (d *InfluxIot) IotAggregateKeep(qi bulkQuerygen.Query, timeRange time.Durat
 		query = fmt.Sprintf(`from(bucket: "%s") `+
 			`|> range(start: %s, stop: %s) `+
 			`|> filter(fn: (r) => r._measurement == "air_quality_room" and r._field == "co2_level")`+
-			`|> filter(fn: (r) => r.room_id == 4)`+
+			`|> filter(fn: (r) => r.room_id == "4")`+
 			`|> keep(columns: ["_time", "_value"])`+
 			`|> aggregateWindow(every: 5m, fn: mean)`,
 			d.DatabaseName,


### PR DESCRIPTION
Fixes an issue in the flux query for `iot` `aggregate-keep` not being in quotations, causing the query to fail