### PR TITLE
feat: add aliases to describe query ops for IoT use case

### DIFF
--- a/cmd/bulk_query_gen/main.go
+++ b/cmd/bulk_query_gen/main.go
@@ -35,6 +35,9 @@ const (
 	IotLightLevelEightHours         = "light-level-8-hr"
 	IotBatteryLevels                = "battery-levels"
 	IotSortedPivot                  = "sorted-pivot"
+	IotFastQuery                    = "fast-query"
+	IotMultiMeasurementOr           = "multi-measurement-or"
+	IotStandAloneFilter             = "standalone-filter"
 	DashboardAll                    = "dashboard-all"
 	DashboardAvailability           = "availability"
 	DashboardCpuNum                 = "cpu-num"
@@ -113,6 +116,10 @@ var useCaseMatrix = map[string]map[string]map[string]bulkQueryGen.QueryGenerator
 			"cassandra":        cassandra.NewCassandraIotSingleHost,
 			"mongo":            mongodb.NewMongoIotSingleHost,
 		},
+		IotFastQuery: { // alias for IotOneHomeTwelveHours
+			"influx-flux-http": influxdb.NewFluxIotSingleHost,
+			"influx-http":      influxdb.NewInfluxQLIotSingleHost,
+		},
 		IotAggregateKeep: {
 			"influx-flux-http": influxdb.NewFluxIotAggregateKeep,
 			"influx-http":      influxdb.NewInfluxQLIotAggregateKeep,
@@ -121,7 +128,15 @@ var useCaseMatrix = map[string]map[string]map[string]bulkQueryGen.QueryGenerator
 			"influx-flux-http": influxdb.NewFluxIotLightLevel,
 			"influx-http":      influxdb.NewInfluxQLIotLightLevel,
 		},
+		IotStandAloneFilter: { // alias for IotLightLevelEightHours
+			"influx-flux-http": influxdb.NewFluxIotLightLevel,
+			"influx-http":      influxdb.NewInfluxQLIotLightLevel,
+		},
 		IotBatteryLevels: {
+			"influx-flux-http": influxdb.NewFluxIotBatteryLevels,
+			"influx-http":      influxdb.NewInfluxQLIotBatteryLevels,
+		},
+		IotMultiMeasurementOr: { // alias for IotBatteryLevels
 			"influx-flux-http": influxdb.NewFluxIotBatteryLevels,
 			"influx-http":      influxdb.NewInfluxQLIotBatteryLevels,
 		},

--- a/cmd/bulk_query_gen/main.go
+++ b/cmd/bulk_query_gen/main.go
@@ -35,7 +35,7 @@ const (
 	IotLightLevelEightHours         = "light-level-8-hr"
 	IotBatteryLevels                = "battery-levels"
 	IotSortedPivot                  = "sorted-pivot"
-	IotFastQuery                    = "fast-query"
+	IotFastQuerySmallData           = "fast-query-small-data"
 	IotMultiMeasurementOr           = "multi-measurement-or"
 	IotStandAloneFilter             = "standalone-filter"
 	DashboardAll                    = "dashboard-all"


### PR DESCRIPTION
This adds the ability to generate queries for a few query types in the IoT use case with alternate names that will be more descriptive as to the shape of the query for our automated performance benchmarks.

Since some of these queries were created specifically for the performance benchmarks, a follow-up PR will remove the query types that are being aliased off of to clean things up after the automated perf tests have switched to the new names.

The mapping is as follows:
- `1-home-12-hours`: `fast-query-small-data`
- `battery-levels`: `multi-measurement-or`
- `light-level-8-hr`: `standalone-filter`
