### PR TITLE
feat: add iot query case for aggregate-drop

### DIFF
--- a/bulk_query_gen/influxdb/influx_iot_aggregate_drop.go
+++ b/bulk_query_gen/influxdb/influx_iot_aggregate_drop.go
@@ -1,0 +1,36 @@
+package influxdb
+
+import (
+	"time"
+
+	bulkQuerygen "github.com/influxdata/influxdb-comparisons/bulk_query_gen"
+)
+
+// InfluxIotAggregateDrop produces queries that will test performance
+// on Flux statements with drop() |> aggregateWindow()
+type InfluxIotAggregateDrop struct {
+	InfluxIot
+	interval time.Duration
+}
+
+func NewInfluxQLIotAggregateDrop(dbConfig bulkQuerygen.DatabaseConfig, queriesFullRange bulkQuerygen.TimeInterval, queryInterval time.Duration, scaleVar int) bulkQuerygen.QueryGenerator {
+	underlying := NewInfluxIotCommon(InfluxQL, dbConfig, queriesFullRange, queryInterval, scaleVar).(*InfluxIot)
+	return &InfluxIotAggregateDrop{
+		InfluxIot: *underlying,
+		interval: queryInterval,
+	}
+}
+
+func NewFluxIotAggregateDrop(dbConfig bulkQuerygen.DatabaseConfig, queriesFullRange bulkQuerygen.TimeInterval, queryInterval time.Duration, scaleVar int) bulkQuerygen.QueryGenerator {
+	underlying := NewInfluxIotCommon(Flux, dbConfig, queriesFullRange, queryInterval, scaleVar).(*InfluxIot)
+	return &InfluxIotAggregateDrop{
+		InfluxIot: *underlying,
+		interval: queryInterval,
+	}
+}
+
+func (d *InfluxIotAggregateDrop) Dispatch(i int) bulkQuerygen.Query {
+	q := bulkQuerygen.NewHTTPQuery() // from pool
+	d.IotAggregateDrop(q, d.interval)
+	return q
+}

--- a/bulk_query_gen/influxdb/influx_iot_aggregate_keep.go
+++ b/bulk_query_gen/influxdb/influx_iot_aggregate_keep.go
@@ -1,12 +1,13 @@
 package influxdb
 
 import (
-	bulkQuerygen "github.com/influxdata/influxdb-comparisons/bulk_query_gen"
 	"time"
+
+	bulkQuerygen "github.com/influxdata/influxdb-comparisons/bulk_query_gen"
 )
 
 // InfluxIotAggregateKeep produces queries that will test performance
-// on Flux statements aggregate and keep
+// on Flux statements with keep() |> aggregateWindow()
 type InfluxIotAggregateKeep struct {
 	InfluxIot
 	interval time.Duration

--- a/cmd/bulk_query_gen/main.go
+++ b/cmd/bulk_query_gen/main.go
@@ -32,6 +32,7 @@ const (
 	DevOpsGroupBy                   = "groupby"
 	IotOneHomeTwelveHours           = "1-home-12-hours"
 	IotAggregateKeep                = "aggregate-keep"
+	IotAggregateDrop                = "aggregate-drop"
 	IotSortedPivot                  = "sorted-pivot"
 	IotFastQuerySmallData           = "fast-query-small-data"
 	IotMultiMeasurementOr           = "multi-measurement-or"
@@ -121,6 +122,10 @@ var useCaseMatrix = map[string]map[string]map[string]bulkQueryGen.QueryGenerator
 		IotAggregateKeep: {
 			"influx-flux-http": influxdb.NewFluxIotAggregateKeep,
 			"influx-http":      influxdb.NewInfluxQLIotAggregateKeep,
+		},
+		IotAggregateDrop: {
+			"influx-flux-http": influxdb.NewFluxIotAggregateDrop,
+			"influx-http":      influxdb.NewInfluxQLIotAggregateDrop,
 		},
 		IotStandAloneFilter: {
 			"influx-flux-http": influxdb.NewFluxIotStandAloneFilter,


### PR DESCRIPTION
`drop` is the mirror to `keep`. I suspect that `keep` will be easier to optimize than `drop` (in the same way that our `group` pushdown works for `mode: by` and not `mode: except`), so it'd be good to track both separately.