### PR TITLE
chore: add aliases for group window based on cardinality on use case

### DIFF
--- a/bulk_data_gen/common/simulation.go
+++ b/bulk_data_gen/common/simulation.go
@@ -3,17 +3,19 @@ package common
 import "time"
 
 const (
-	DefaultDateTimeStart        = "2018-01-01T00:00:00Z"
-	DefaultDateTimeEnd          = "2018-01-02T00:00:00Z"
-	UseCaseDevOps               = "devops"
-	UseCaseIot                  = "iot"
-	UseCaseDashboard            = "dashboard"
-	UseCaseMetaquery            = "metaquery"
-	UseCaseWindowAggregate      = "window-agg"
-	UseCaseGroupAggregate       = "group-agg"
-	UseCaseBareAggregate        = "bare-agg"
-	UseCaseGroupWindowTranspose = "group-window-transpose"
-	UseCaseMultiMeasurement     = "multi-measurement"
+	DefaultDateTimeStart                = "2018-01-01T00:00:00Z"
+	DefaultDateTimeEnd                  = "2018-01-02T00:00:00Z"
+	UseCaseDevOps                       = "devops"
+	UseCaseIot                          = "iot"
+	UseCaseDashboard                    = "dashboard"
+	UseCaseMetaquery                    = "metaquery"
+	UseCaseWindowAggregate              = "window-agg"
+	UseCaseGroupAggregate               = "group-agg"
+	UseCaseBareAggregate                = "bare-agg"
+	UseCaseGroupWindowTranspose         = "group-window-transpose"
+	UseCaseGroupWindowTransposeHighCard = "group-window-transpose-high-card"
+	UseCaseGroupWindowTransposeLowCard  = "group-window-transpose-low-card"
+	UseCaseMultiMeasurement             = "multi-measurement"
 )
 
 // Use case choices:

--- a/cmd/bulk_query_gen/main.go
+++ b/cmd/bulk_query_gen/main.go
@@ -372,6 +372,66 @@ var useCaseMatrix = map[string]map[string]map[string]bulkQueryGen.QueryGenerator
 			"influx-http":      influxdb.NewInfluxQLGroupWindowTransposeMaxCardinality,
 		},
 	},
+	common.UseCaseGroupWindowTransposeHighCard: {
+		string(influxdb.Count): {
+			"influx-flux-http": influxdb.NewFluxGroupWindowTransposeCountCardinality,
+			"influx-http":      influxdb.NewInfluxQLGroupWindowTransposeCountCardinality,
+		},
+		string(influxdb.Sum): {
+			"influx-flux-http": influxdb.NewFluxGroupWindowTransposeSumCardinality,
+			"influx-http":      influxdb.NewInfluxQLGroupWindowTransposeSumCardinality,
+		},
+		string(influxdb.Mean): {
+			"influx-flux-http": influxdb.NewFluxGroupWindowTransposeMeanCardinality,
+			"influx-http":      influxdb.NewInfluxQLGroupWindowTransposeMeanCardinality,
+		},
+		string(influxdb.First): {
+			"influx-flux-http": influxdb.NewFluxGroupWindowTransposeFirstCardinality,
+			"influx-http":      influxdb.NewInfluxQLGroupWindowTransposeFirstCardinality,
+		},
+		string(influxdb.Last): {
+			"influx-flux-http": influxdb.NewFluxGroupWindowTransposeLastCardinality,
+			"influx-http":      influxdb.NewInfluxQLGroupWindowTransposeLastCardinality,
+		},
+		string(influxdb.Min): {
+			"influx-flux-http": influxdb.NewFluxGroupWindowTransposeMinCardinality,
+			"influx-http":      influxdb.NewInfluxQLGroupWindowTransposeMinCardinality,
+		},
+		string(influxdb.Max): {
+			"influx-flux-http": influxdb.NewFluxGroupWindowTransposeMaxCardinality,
+			"influx-http":      influxdb.NewInfluxQLGroupWindowTransposeMaxCardinality,
+		},
+	},
+	common.UseCaseGroupWindowTransposeLowCard: {
+		string(influxdb.Count): {
+			"influx-flux-http": influxdb.NewFluxGroupWindowTransposeCount,
+			"influx-http":      influxdb.NewInfluxQLGroupWindowTransposeCount,
+		},
+		string(influxdb.Sum): {
+			"influx-flux-http": influxdb.NewFluxGroupWindowTransposeSum,
+			"influx-http":      influxdb.NewInfluxQLGroupWindowTransposeSum,
+		},
+		string(influxdb.Mean): {
+			"influx-flux-http": influxdb.NewFluxGroupWindowTransposeMean,
+			"influx-http":      influxdb.NewInfluxQLGroupWindowTransposeMean,
+		},
+		string(influxdb.First): {
+			"influx-flux-http": influxdb.NewFluxGroupWindowTransposeFirst,
+			"influx-http":      influxdb.NewInfluxQLGroupWindowTransposeFirst,
+		},
+		string(influxdb.Last): {
+			"influx-flux-http": influxdb.NewFluxGroupWindowTransposeLast,
+			"influx-http":      influxdb.NewInfluxQLGroupWindowTransposeLast,
+		},
+		string(influxdb.Min): {
+			"influx-flux-http": influxdb.NewFluxGroupWindowTransposeMin,
+			"influx-http":      influxdb.NewInfluxQLGroupWindowTransposeMin,
+		},
+		string(influxdb.Max): {
+			"influx-flux-http": influxdb.NewFluxGroupWindowTransposeMax,
+			"influx-http":      influxdb.NewInfluxQLGroupWindowTransposeMax,
+		},
+	},
 	common.UseCaseMultiMeasurement: {
 		MultiMeasurementOr: {
 			"influx-flux-http": influxdb.NewFluxMultiMeasurementOr,


### PR DESCRIPTION
Related to https://github.com/influxdata/influxdb/issues/22350

This provides aliases that can be used to generate queries for group-window queries based on a use-case, rather than the use case of `group-window-transpose` with different types yielding the high or low cardinality versions of the queries.

The reasoning for this may seem opaque currently, but this should help make the logic for https://github.com/influxdata/influxdb/pull/22480 much simpler, and allow for the high and low cardinality versions of the queries to be created for the correct time range.

The existing use-case is not being removed at this time, so this is purely an additive change and will not break any existing behaviors.