### PR TITLE
chore: delete unused group-window-transpose code

### DIFF
--- a/bulk_data_gen/common/simulation.go
+++ b/bulk_data_gen/common/simulation.go
@@ -12,7 +12,6 @@ const (
 	UseCaseWindowAggregate              = "window-agg"
 	UseCaseGroupAggregate               = "group-agg"
 	UseCaseBareAggregate                = "bare-agg"
-	UseCaseGroupWindowTranspose         = "group-window-transpose"
 	UseCaseGroupWindowTransposeHighCard = "group-window-transpose-high-card"
 	UseCaseGroupWindowTransposeLowCard  = "group-window-transpose-low-card"
 	UseCaseMultiMeasurement             = "multi-measurement"

--- a/cmd/bulk_query_gen/main.go
+++ b/cmd/bulk_query_gen/main.go
@@ -319,64 +319,6 @@ var useCaseMatrix = map[string]map[string]map[string]bulkQueryGen.QueryGenerator
 			"influx-http":      influxdb.NewInfluxQLBareAggregateMax,
 		},
 	},
-	common.UseCaseGroupWindowTranspose: {
-		fmt.Sprintf("%s-%s", influxdb.Count, influxdb.LowCardinality): {
-			"influx-flux-http": influxdb.NewFluxGroupWindowTransposeCount,
-			"influx-http":      influxdb.NewInfluxQLGroupWindowTransposeCount,
-		},
-		fmt.Sprintf("%s-%s", influxdb.Count, influxdb.HighCardinality): {
-			"influx-flux-http": influxdb.NewFluxGroupWindowTransposeCountCardinality,
-			"influx-http":      influxdb.NewInfluxQLGroupWindowTransposeCountCardinality,
-		},
-		fmt.Sprintf("%s-%s", influxdb.Sum, influxdb.LowCardinality): {
-			"influx-flux-http": influxdb.NewFluxGroupWindowTransposeSum,
-			"influx-http":      influxdb.NewInfluxQLGroupWindowTransposeSum,
-		},
-		fmt.Sprintf("%s-%s", influxdb.Sum, influxdb.HighCardinality): {
-			"influx-flux-http": influxdb.NewFluxGroupWindowTransposeSumCardinality,
-			"influx-http":      influxdb.NewInfluxQLGroupWindowTransposeSumCardinality,
-		},
-		fmt.Sprintf("%s-%s", influxdb.Mean, influxdb.LowCardinality): {
-			"influx-flux-http": influxdb.NewFluxGroupWindowTransposeMean,
-			"influx-http":      influxdb.NewInfluxQLGroupWindowTransposeMean,
-		},
-		fmt.Sprintf("%s-%s", influxdb.Mean, influxdb.HighCardinality): {
-			"influx-flux-http": influxdb.NewFluxGroupWindowTransposeMeanCardinality,
-			"influx-http":      influxdb.NewInfluxQLGroupWindowTransposeMeanCardinality,
-		},
-		fmt.Sprintf("%s-%s", influxdb.First, influxdb.LowCardinality): {
-			"influx-flux-http": influxdb.NewFluxGroupWindowTransposeFirst,
-			"influx-http":      influxdb.NewInfluxQLGroupWindowTransposeFirst,
-		},
-		fmt.Sprintf("%s-%s", influxdb.First, influxdb.HighCardinality): {
-			"influx-flux-http": influxdb.NewFluxGroupWindowTransposeFirstCardinality,
-			"influx-http":      influxdb.NewInfluxQLGroupWindowTransposeFirstCardinality,
-		},
-		fmt.Sprintf("%s-%s", influxdb.Last, influxdb.LowCardinality): {
-			"influx-flux-http": influxdb.NewFluxGroupWindowTransposeLast,
-			"influx-http":      influxdb.NewInfluxQLGroupWindowTransposeLast,
-		},
-		fmt.Sprintf("%s-%s", influxdb.Last, influxdb.HighCardinality): {
-			"influx-flux-http": influxdb.NewFluxGroupWindowTransposeLastCardinality,
-			"influx-http":      influxdb.NewInfluxQLGroupWindowTransposeLastCardinality,
-		},
-		fmt.Sprintf("%s-%s", influxdb.Min, influxdb.LowCardinality): {
-			"influx-flux-http": influxdb.NewFluxGroupWindowTransposeMin,
-			"influx-http":      influxdb.NewInfluxQLGroupWindowTransposeMin,
-		},
-		fmt.Sprintf("%s-%s", influxdb.Min, influxdb.HighCardinality): {
-			"influx-flux-http": influxdb.NewFluxGroupWindowTransposeMinCardinality,
-			"influx-http":      influxdb.NewInfluxQLGroupWindowTransposeMinCardinality,
-		},
-		fmt.Sprintf("%s-%s", influxdb.Max, influxdb.LowCardinality): {
-			"influx-flux-http": influxdb.NewFluxGroupWindowTransposeMax,
-			"influx-http":      influxdb.NewInfluxQLGroupWindowTransposeMax,
-		},
-		fmt.Sprintf("%s-%s", influxdb.Max, influxdb.HighCardinality): {
-			"influx-flux-http": influxdb.NewFluxGroupWindowTransposeMaxCardinality,
-			"influx-http":      influxdb.NewInfluxQLGroupWindowTransposeMaxCardinality,
-		},
-	},
 	common.UseCaseGroupWindowTransposeHighCard: {
 		string(influxdb.Count): {
 			"influx-flux-http": influxdb.NewFluxGroupWindowTransposeCountCardinality,


### PR DESCRIPTION
Closes #203

Removes the now unused alias for `group-window-transpose`, since the full `group-window-transpose-high-card` & `group-window-transpose-low-card` are being used instead.