### PR TITLE
feat: add query-gen cases for "ungrouped" aggregates

### DIFF
--- a/bulk_data_gen/common/simulation.go
+++ b/bulk_data_gen/common/simulation.go
@@ -12,6 +12,7 @@ const (
 	UseCaseWindowAggregate              = "window-agg"
 	UseCaseGroupAggregate               = "group-agg"
 	UseCaseBareAggregate                = "bare-agg"
+	UseCaseUngroupedAggregate           = "ungrouped-agg"
 	UseCaseGroupWindowTransposeHighCard = "group-window-transpose-high-card"
 	UseCaseGroupWindowTransposeLowCard  = "group-window-transpose-low-card"
 	UseCaseMultiMeasurement             = "multi-measurement"
@@ -26,6 +27,7 @@ var UseCaseChoices = []string{
 	UseCaseWindowAggregate,
 	UseCaseGroupAggregate,
 	UseCaseBareAggregate,
+	UseCaseUngroupedAggregate,
 	UseCaseMultiMeasurement,
 }
 

--- a/bulk_query_gen/influxdb/influx_ungroupedagg_common.go
+++ b/bulk_query_gen/influxdb/influx_ungroupedagg_common.go
@@ -1,0 +1,54 @@
+package influxdb
+
+import (
+	"fmt"
+	"time"
+
+	bulkQuerygen "github.com/influxdata/influxdb-comparisons/bulk_query_gen"
+)
+
+type InfluxUngroupedAggregateQuery struct {
+	InfluxCommon
+	aggregate Aggregate
+}
+
+func NewInfluxUngroupedAggregateQuery(agg Aggregate, lang Language, dbConfig bulkQuerygen.DatabaseConfig, queriesFullRange bulkQuerygen.TimeInterval, scaleVar int) bulkQuerygen.QueryGenerator {
+	if _, ok := dbConfig[bulkQuerygen.DatabaseName]; !ok {
+		panic("need influx database na`me")
+	}
+
+	return &InfluxUngroupedAggregateQuery{
+		InfluxCommon: *newInfluxCommon(lang, dbConfig[bulkQuerygen.DatabaseName], queriesFullRange, scaleVar),
+		aggregate:    agg,
+	}
+}
+
+func (d *InfluxUngroupedAggregateQuery) Dispatch(i int) bulkQuerygen.Query {
+	q := bulkQuerygen.NewHTTPQuery()
+	d.UngroupedAggregateQuery(q)
+	return q
+}
+
+func (d *InfluxUngroupedAggregateQuery) UngroupedAggregateQuery(qi bulkQuerygen.Query) {
+	interval := d.AllInterval.RandWindow(time.Hour * 6)
+
+	var query string
+	if d.language == InfluxQL {
+		query = fmt.Sprintf("SELECT %s(temperature) FROM air_condition_room WHERE time >= '%s' AND time < '%s'",
+			d.aggregate, interval.StartString(), interval.EndString())
+	} else {
+		query = fmt.Sprintf(`from(bucket:"%s")
+            |> range(start:%s, stop:%s)
+            |> filter(fn:(r) => r._measurement == "air_condition_room" and r._field == "temperature")
+            |> group()
+            |> %s()
+            |> yield()`,
+			d.DatabaseName,
+			interval.StartString(), interval.EndString(),
+			d.aggregate)
+	}
+
+	humanLabel := fmt.Sprintf("InfluxDB (%s) %s temperature, rand %s", d.language.String(), d.aggregate, interval.StartString())
+	q := qi.(*bulkQuerygen.HTTPQuery)
+	d.getHttpQuery(humanLabel, interval.StartString(), query, q)
+}

--- a/bulk_query_gen/influxdb/influx_ungroupedagg_common.go
+++ b/bulk_query_gen/influxdb/influx_ungroupedagg_common.go
@@ -14,7 +14,7 @@ type InfluxUngroupedAggregateQuery struct {
 
 func NewInfluxUngroupedAggregateQuery(agg Aggregate, lang Language, dbConfig bulkQuerygen.DatabaseConfig, queriesFullRange bulkQuerygen.TimeInterval, scaleVar int) bulkQuerygen.QueryGenerator {
 	if _, ok := dbConfig[bulkQuerygen.DatabaseName]; !ok {
-		panic("need influx database na`me")
+		panic("need influx database name")
 	}
 
 	return &InfluxUngroupedAggregateQuery{

--- a/bulk_query_gen/influxdb/influx_ungroupedagg_count.go
+++ b/bulk_query_gen/influxdb/influx_ungroupedagg_count.go
@@ -1,0 +1,15 @@
+package influxdb
+
+import (
+	"time"
+
+	bulkQuerygen "github.com/influxdata/influxdb-comparisons/bulk_query_gen"
+)
+
+func NewInfluxQLUngroupedAggregateCount(dbConfig bulkQuerygen.DatabaseConfig, queriesFullRange bulkQuerygen.TimeInterval, _ time.Duration, scaleVar int) bulkQuerygen.QueryGenerator {
+	return NewInfluxUngroupedAggregateQuery(Count, InfluxQL, dbConfig, queriesFullRange, scaleVar)
+}
+
+func NewFluxUngroupedAggregateCount(dbConfig bulkQuerygen.DatabaseConfig, queriesFullRange bulkQuerygen.TimeInterval, _ time.Duration, scaleVar int) bulkQuerygen.QueryGenerator {
+	return NewInfluxUngroupedAggregateQuery(Count, Flux, dbConfig, queriesFullRange, scaleVar)
+}

--- a/bulk_query_gen/influxdb/influx_ungroupedagg_first.go
+++ b/bulk_query_gen/influxdb/influx_ungroupedagg_first.go
@@ -1,0 +1,15 @@
+package influxdb
+
+import (
+	"time"
+
+	bulkQuerygen "github.com/influxdata/influxdb-comparisons/bulk_query_gen"
+)
+
+func NewInfluxQLUngroupedAggregateFirst(dbConfig bulkQuerygen.DatabaseConfig, queriesFullRange bulkQuerygen.TimeInterval, _ time.Duration, scaleVar int) bulkQuerygen.QueryGenerator {
+	return NewInfluxUngroupedAggregateQuery(First, InfluxQL, dbConfig, queriesFullRange, scaleVar)
+}
+
+func NewFluxUngroupedAggregateFirst(dbConfig bulkQuerygen.DatabaseConfig, queriesFullRange bulkQuerygen.TimeInterval, _ time.Duration, scaleVar int) bulkQuerygen.QueryGenerator {
+	return NewInfluxUngroupedAggregateQuery(First, Flux, dbConfig, queriesFullRange, scaleVar)
+}

--- a/bulk_query_gen/influxdb/influx_ungroupedagg_last.go
+++ b/bulk_query_gen/influxdb/influx_ungroupedagg_last.go
@@ -1,0 +1,15 @@
+package influxdb
+
+import (
+	"time"
+
+	bulkQuerygen "github.com/influxdata/influxdb-comparisons/bulk_query_gen"
+)
+
+func NewInfluxQLUngroupedAggregateLast(dbConfig bulkQuerygen.DatabaseConfig, queriesFullRange bulkQuerygen.TimeInterval, _ time.Duration, scaleVar int) bulkQuerygen.QueryGenerator {
+	return NewInfluxUngroupedAggregateQuery(Last, InfluxQL, dbConfig, queriesFullRange, scaleVar)
+}
+
+func NewFluxUngroupedAggregateLast(dbConfig bulkQuerygen.DatabaseConfig, queriesFullRange bulkQuerygen.TimeInterval, _ time.Duration, scaleVar int) bulkQuerygen.QueryGenerator {
+	return NewInfluxUngroupedAggregateQuery(Last, Flux, dbConfig, queriesFullRange, scaleVar)
+}

--- a/bulk_query_gen/influxdb/influx_ungroupedagg_max.go
+++ b/bulk_query_gen/influxdb/influx_ungroupedagg_max.go
@@ -1,0 +1,15 @@
+package influxdb
+
+import (
+	"time"
+
+	bulkQuerygen "github.com/influxdata/influxdb-comparisons/bulk_query_gen"
+)
+
+func NewInfluxQLUngroupedAggregateMax(dbConfig bulkQuerygen.DatabaseConfig, queriesFullRange bulkQuerygen.TimeInterval, _ time.Duration, scaleVar int) bulkQuerygen.QueryGenerator {
+	return NewInfluxUngroupedAggregateQuery(Max, InfluxQL, dbConfig, queriesFullRange, scaleVar)
+}
+
+func NewFluxUngroupedAggregateMax(dbConfig bulkQuerygen.DatabaseConfig, queriesFullRange bulkQuerygen.TimeInterval, _ time.Duration, scaleVar int) bulkQuerygen.QueryGenerator {
+	return NewInfluxUngroupedAggregateQuery(Max, Flux, dbConfig, queriesFullRange, scaleVar)
+}

--- a/bulk_query_gen/influxdb/influx_ungroupedagg_mean.go
+++ b/bulk_query_gen/influxdb/influx_ungroupedagg_mean.go
@@ -1,0 +1,15 @@
+package influxdb
+
+import (
+	"time"
+
+	bulkQuerygen "github.com/influxdata/influxdb-comparisons/bulk_query_gen"
+)
+
+func NewInfluxQLUngroupedAggregateMean(dbConfig bulkQuerygen.DatabaseConfig, queriesFullRange bulkQuerygen.TimeInterval, _ time.Duration, scaleVar int) bulkQuerygen.QueryGenerator {
+	return NewInfluxUngroupedAggregateQuery(Mean, InfluxQL, dbConfig, queriesFullRange, scaleVar)
+}
+
+func NewFluxUngroupedAggregateMean(dbConfig bulkQuerygen.DatabaseConfig, queriesFullRange bulkQuerygen.TimeInterval, _ time.Duration, scaleVar int) bulkQuerygen.QueryGenerator {
+	return NewInfluxUngroupedAggregateQuery(Mean, Flux, dbConfig, queriesFullRange, scaleVar)
+}

--- a/bulk_query_gen/influxdb/influx_ungroupedagg_min.go
+++ b/bulk_query_gen/influxdb/influx_ungroupedagg_min.go
@@ -1,0 +1,15 @@
+package influxdb
+
+import (
+	"time"
+
+	bulkQuerygen "github.com/influxdata/influxdb-comparisons/bulk_query_gen"
+)
+
+func NewInfluxQLUngroupedAggregateMin(dbConfig bulkQuerygen.DatabaseConfig, queriesFullRange bulkQuerygen.TimeInterval, _ time.Duration, scaleVar int) bulkQuerygen.QueryGenerator {
+	return NewInfluxUngroupedAggregateQuery(Min, InfluxQL, dbConfig, queriesFullRange, scaleVar)
+}
+
+func NewFluxUngroupedAggregateMin(dbConfig bulkQuerygen.DatabaseConfig, queriesFullRange bulkQuerygen.TimeInterval, _ time.Duration, scaleVar int) bulkQuerygen.QueryGenerator {
+	return NewInfluxUngroupedAggregateQuery(Min, Flux, dbConfig, queriesFullRange, scaleVar)
+}

--- a/bulk_query_gen/influxdb/influx_ungroupedagg_sum.go
+++ b/bulk_query_gen/influxdb/influx_ungroupedagg_sum.go
@@ -1,0 +1,15 @@
+package influxdb
+
+import (
+	"time"
+
+	bulkQuerygen "github.com/influxdata/influxdb-comparisons/bulk_query_gen"
+)
+
+func NewInfluxQLUngroupedAggregateSum(dbConfig bulkQuerygen.DatabaseConfig, queriesFullRange bulkQuerygen.TimeInterval, _ time.Duration, scaleVar int) bulkQuerygen.QueryGenerator {
+	return NewInfluxUngroupedAggregateQuery(Sum, InfluxQL, dbConfig, queriesFullRange, scaleVar)
+}
+
+func NewFluxUngroupedAggregateSum(dbConfig bulkQuerygen.DatabaseConfig, queriesFullRange bulkQuerygen.TimeInterval, _ time.Duration, scaleVar int) bulkQuerygen.QueryGenerator {
+	return NewInfluxUngroupedAggregateQuery(Sum, Flux, dbConfig, queriesFullRange, scaleVar)
+}

--- a/cmd/bulk_data_gen/main.go
+++ b/cmd/bulk_data_gen/main.go
@@ -209,6 +209,8 @@ func main() {
 		fallthrough
 	case common.UseCaseChoices[6]: // bare-agg:
 		fallthrough
+	case common.UseCaseChoices[7]: // ungrouped-agg:
+		fallthrough
 	case common.UseCaseChoices[1]:
 		cfg := &iot.IotSimulatorConfig{
 			Start: timestampStart,
@@ -226,7 +228,7 @@ func main() {
 			ScaleFactor: int(scaleVar),
 		}
 		sim = cfg.ToSimulator()
-	case common.UseCaseChoices[7]:
+	case common.UseCaseChoices[8]:
 		cfg := &multiMeasurement.MeasurementSimulatorConfig{
 			Start: timestampStart,
 			End:   timestampEnd,

--- a/cmd/bulk_query_gen/main.go
+++ b/cmd/bulk_query_gen/main.go
@@ -319,6 +319,36 @@ var useCaseMatrix = map[string]map[string]map[string]bulkQueryGen.QueryGenerator
 			"influx-http":      influxdb.NewInfluxQLBareAggregateMax,
 		},
 	},
+	common.UseCaseUngroupedAggregate: {
+		string(influxdb.Count): {
+			"influx-flux-http": influxdb.NewFluxAllAggregateCount,
+			"influx-http":      influxdb.NewInfluxQLAllAggregateCount,
+		},
+		string(influxdb.Sum): {
+			"influx-flux-http": influxdb.NewFluxAllAggregateSum,
+			"influx-http":      influxdb.NewInfluxQLAllAggregateSum,
+		},
+		string(influxdb.Mean): {
+			"influx-flux-http": influxdb.NewFluxAllAggregateMean,
+			"influx-http":      influxdb.NewInfluxQLAllAggregateMean,
+		},
+		string(influxdb.First): {
+			"influx-flux-http": influxdb.NewFluxAllAggregateFirst,
+			"influx-http":      influxdb.NewInfluxQLAllAggregateFirst,
+		},
+		string(influxdb.Last): {
+			"influx-flux-http": influxdb.NewFluxAllAggregateLast,
+			"influx-http":      influxdb.NewInfluxQLAllAggregateLast,
+		},
+		string(influxdb.Min): {
+			"influx-flux-http": influxdb.NewFluxAllAggregateMin,
+			"influx-http":      influxdb.NewInfluxQLAllAggregateMin,
+		},
+		string(influxdb.Max): {
+			"influx-flux-http": influxdb.NewFluxAllAggregateMax,
+			"influx-http":      influxdb.NewInfluxQLAllAggregateMax,
+		},
+	},
 	common.UseCaseGroupWindowTransposeHighCard: {
 		string(influxdb.Count): {
 			"influx-flux-http": influxdb.NewFluxGroupWindowTransposeCountCardinality,

--- a/cmd/bulk_query_gen/main.go
+++ b/cmd/bulk_query_gen/main.go
@@ -321,32 +321,32 @@ var useCaseMatrix = map[string]map[string]map[string]bulkQueryGen.QueryGenerator
 	},
 	common.UseCaseUngroupedAggregate: {
 		string(influxdb.Count): {
-			"influx-flux-http": influxdb.NewFluxAllAggregateCount,
-			"influx-http":      influxdb.NewInfluxQLAllAggregateCount,
+			"influx-flux-http": influxdb.NewFluxUngroupedAggregateCount,
+			"influx-http":      influxdb.NewInfluxQLUngroupedAggregateCount,
 		},
 		string(influxdb.Sum): {
-			"influx-flux-http": influxdb.NewFluxAllAggregateSum,
-			"influx-http":      influxdb.NewInfluxQLAllAggregateSum,
+			"influx-flux-http": influxdb.NewFluxUngroupedAggregateSum,
+			"influx-http":      influxdb.NewInfluxQLUngroupedAggregateSum,
 		},
 		string(influxdb.Mean): {
-			"influx-flux-http": influxdb.NewFluxAllAggregateMean,
-			"influx-http":      influxdb.NewInfluxQLAllAggregateMean,
+			"influx-flux-http": influxdb.NewFluxUngroupedAggregateMean,
+			"influx-http":      influxdb.NewInfluxQLUngroupedAggregateMean,
 		},
 		string(influxdb.First): {
-			"influx-flux-http": influxdb.NewFluxAllAggregateFirst,
-			"influx-http":      influxdb.NewInfluxQLAllAggregateFirst,
+			"influx-flux-http": influxdb.NewFluxUngroupedAggregateFirst,
+			"influx-http":      influxdb.NewInfluxQLUngroupedAggregateFirst,
 		},
 		string(influxdb.Last): {
-			"influx-flux-http": influxdb.NewFluxAllAggregateLast,
-			"influx-http":      influxdb.NewInfluxQLAllAggregateLast,
+			"influx-flux-http": influxdb.NewFluxUngroupedAggregateLast,
+			"influx-http":      influxdb.NewInfluxQLUngroupedAggregateLast,
 		},
 		string(influxdb.Min): {
-			"influx-flux-http": influxdb.NewFluxAllAggregateMin,
-			"influx-http":      influxdb.NewInfluxQLAllAggregateMin,
+			"influx-flux-http": influxdb.NewFluxUngroupedAggregateMin,
+			"influx-http":      influxdb.NewInfluxQLUngroupedAggregateMin,
 		},
 		string(influxdb.Max): {
-			"influx-flux-http": influxdb.NewFluxAllAggregateMax,
-			"influx-http":      influxdb.NewInfluxQLAllAggregateMax,
+			"influx-flux-http": influxdb.NewFluxUngroupedAggregateMax,
+			"influx-http":      influxdb.NewInfluxQLUngroupedAggregateMax,
 		},
 	},
 	common.UseCaseGroupWindowTransposeHighCard: {


### PR DESCRIPTION
After #207, we're missing a test for aggregates over the entirety of a dataset (ungrouped & un-windowed). In OSS using `group()` causes the group-aggregate pushdown to be triggered, but I think within the pushdown logic it ends up using a different iterator/cursor than you'd get with `group(columns: ["foo", "bar"])`.