### PR TITLE
Fix build on Go 1.18 or newer

### DIFF
--- a/bulk_query/query.go
+++ b/bulk_query/query.go
@@ -428,10 +428,8 @@ loop:
 	// channel when done:
 	log.Println("Waiting for workers to finish")
 	waitCh := make(chan int)
-	waitFinished := false
 	go func() {
 		workersGroup.Wait()
-		waitFinished = true
 		waitCh <- 1
 	}()
 	waitTimer := time.NewTimer(time.Minute * 10)


### PR DESCRIPTION
waitFinished was never actually used (initialized and then assigned from
within a goroutine, but value was never checked).

Not catching that was a bug in Golang that was fixed in 1.18
See: https://golang.org/issue/8560