### PR TITLE
fix: MongoDB schema and iot use-case

### DIFF
--- a/bulk_query_gen/cassandra/cassandra_iot_common.go
+++ b/bulk_query_gen/cassandra/cassandra_iot_common.go
@@ -32,7 +32,7 @@ func (d *CassandraIot) Dispatch(i int) bulkQuerygen.Query {
 }
 
 func (d *CassandraIot) AverageTemperatureDayByHourOneHome(q bulkQuerygen.Query) {
-	d.averageTemperatureDayByHourNHomes(q.(*CassandraQuery), 1, time.Hour*6)
+	d.averageTemperatureDayByHourNHomes(q.(*CassandraQuery), 1, time.Hour*12)
 }
 
 // averageTemperatureHourByMinuteNHomes populates a Query with a query that looks like:

--- a/bulk_query_gen/influxdb/influx_iot_common.go
+++ b/bulk_query_gen/influxdb/influx_iot_common.go
@@ -34,7 +34,7 @@ func (d *InfluxIot) Dispatch(i int) bulkQuerygen.Query {
 }
 
 func (d *InfluxIot) AverageTemperatureDayByHourOneHome(q bulkQuerygen.Query) {
-	d.averageTemperatureDayByHourNHomes(q.(*bulkQuerygen.HTTPQuery), 1, time.Hour*6)
+	d.averageTemperatureDayByHourNHomes(q.(*bulkQuerygen.HTTPQuery), 1, time.Hour*12)
 }
 
 // averageTemperatureDayByHourNHomes populates a Query with a query that looks like:

--- a/bulk_query_gen/mongodb/options.go
+++ b/bulk_query_gen/mongodb/options.go
@@ -1,5 +1,10 @@
 package mongodb
 
+import (
+	"log"
+	"strings"
+)
+
 const (
 	FlatFormat = "flat"
 	KeyPairFormat = "key-pair"
@@ -8,3 +13,25 @@ const (
 
 var DocumentFormat = FlatFormat
 var UseTimeseries = false
+var UseSingleCollection = false
+
+func ParseOptions(documentFormat string, oneCollection bool) {
+	switch documentFormat {
+	case FlatFormat, KeyPairFormat, TimeseriesFormat:
+		DocumentFormat = documentFormat
+	default:
+		log.Fatalf("unsupported document format: '%s'", documentFormat)
+	}
+	UseTimeseries = strings.Contains(documentFormat, TimeseriesFormat)
+	if UseTimeseries {
+		log.Print("Using MongoDB 5+ time series collection")
+		DocumentFormat = FlatFormat
+	}
+	log.Printf("Using %s point serialization", DocumentFormat)
+	UseSingleCollection = oneCollection
+	if UseSingleCollection {
+		log.Println("Using single collection for all measurements")
+	} else {
+		log.Println("Using collections per measurement type")
+	}
+}

--- a/bulk_query_gen/timescaledb/timescale_iot_common.go
+++ b/bulk_query_gen/timescaledb/timescale_iot_common.go
@@ -35,7 +35,7 @@ func (d *TimescaleIot) Dispatch(i int) bulkQuerygen.Query {
 }
 
 func (d *TimescaleIot) AverageTemperatureDayByHourOneHome(q bulkQuerygen.Query) {
-	d.averageTemperatureDayByHourNHomes(q.(*SQLQuery), 1, time.Hour*6)
+	d.averageTemperatureDayByHourNHomes(q.(*SQLQuery), 1, time.Hour*12)
 }
 
 // averageTemperatureHourByMinuteNHomes populates a Query with a query that looks like:


### PR DESCRIPTION
This PR adds support for "schema" where measurements are stored in separate collections by type (eg. cpu, network). It is default behavior.
Also fixes `1-home-12-hours` _iot_ query duration to match the query name.